### PR TITLE
Add some new instructions for assembler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /doc/
 /tmp/
 /.inch/
+
+# Vim swap files
+**/.*sw?

--- a/lib/seccomp-tools/asm/compiler.rb
+++ b/lib/seccomp-tools/asm/compiler.rb
@@ -140,7 +140,6 @@ module SeccompTools
 
       def label_offset(label)
         if label.is_a?(Integer)
-          raise ArgumentError, 'Loop detected!' if label.zero?
           raise ArgumentError, 'Does not support backward jumping.' if label.negative?
 
           return label

--- a/lib/seccomp-tools/asm/compiler.rb
+++ b/lib/seccomp-tools/asm/compiler.rb
@@ -140,16 +140,17 @@ module SeccompTools
 
       def label_offset(label)
         if label.is_a?(Integer)
-          raise ArgumentError, "Loop detected!" if label == 0
-          raise ArgumentError, "Does not support backward jumping." if label < 0
+          raise ArgumentError, 'Loop detected!' if label.zero?
+          raise ArgumentError, 'Does not support backward jumping.' if label.negative?
+
           return label
         end
         return label if label.is_a?(Integer)
         return 0 if label == 'next'
         raise ArgumentError, "Undefined label #{label.inspect}" if @labels[label].nil?
-
-        raise ArgumentError, "Loop detected!" if @labels[label] == @line
+        raise ArgumentError, 'Loop detected!' if @labels[label] == @line
         raise ArgumentError, "Does not support backward jumping to #{label.inspect}" if @labels[label] < @line
+
         @labels[label] - @line - 1
       end
 
@@ -180,12 +181,12 @@ module SeccompTools
 
       # <goto|jmp|jump> <label|Integer>
       def jmp_abs
-         tk = token.fetch('goto') ||
-              token.fetch('jmp') ||
-              token.fetch('jump') ||
-              raise(ArgumentError, 'Invalid jump alias: ' + token.cur.inspect)
-         target = token.fetch!(:goto)
-         return [:jmp_abs, target]
+        token.fetch('goto') ||
+          token.fetch('jmp') ||
+          token.fetch('jump') ||
+          raise(ArgumentError, 'Invalid jump alias: ' + token.cur.inspect)
+        target = token.fetch!(:goto)
+        [:jmp_abs, target]
       end
 
       # A <comparison> <sys_str|X|Integer> ? <label|Integer> : <label|Integer>

--- a/lib/seccomp-tools/asm/compiler.rb
+++ b/lib/seccomp-tools/asm/compiler.rb
@@ -100,7 +100,7 @@ module SeccompTools
         # now src must be in form [:mem/:data, num]
         return emit(ld, :mem, k: src.last) if src.first == :mem
         # check if num is multiple of 4
-        raise ArgumentError, 'Index of data[] must be multiplication of 4' if src.last % 4 != 0
+        raise ArgumentError, 'Index of data[] must be a multiple of 4' if src.last % 4 != 0
 
         emit(ld, :abs, k: src.last)
       end

--- a/lib/seccomp-tools/asm/tokenizer.rb
+++ b/lib/seccomp-tools/asm/tokenizer.rb
@@ -130,7 +130,7 @@ Invalid return type: #{cur.inspect}.
       end
 
       def fetch_ary
-        support_name = %w[data mem args]
+        support_name = %w[data mem args args_h]
         regexp = /(#{support_name.join('|')})\[[0-9]{1,2}\]/
         match = fetch_regexp(regexp)
         return nil if match.nil?

--- a/spec/asm/compiler_spec.rb
+++ b/spec/asm/compiler_spec.rb
@@ -32,12 +32,15 @@ describe SeccompTools::Asm::Compiler do
       expect(@get_bpf['A = data[0]']).to eq 'A = sys_number'
       expect { @get_bpf['A = data[1]'] }.to raise_error(ArgumentError, <<-EOS.strip)
 Invalid instruction at line 1: "A = data[1]"
-Error: Index of data[] must be multiplication of 4
+Error: Index of data[] must be a multiple of 4
       EOS
       expect(@get_bpf['A = sys_number']).to eq 'A = sys_number'
       expect(@get_bpf['A = arch']).to eq 'A = arch'
+      expect(@get_bpf['A = len']).to eq 'A = 64'
       expect(@get_bpf['A = args[0]']).to eq 'A = args[0]'
       expect(@get_bpf['A = args[1]']).to eq 'A = args[1]'
+      expect(@get_bpf['A = args_h[0]']).to eq 'A = args[0] >> 32'
+      expect(@get_bpf['A = args_h[1]']).to eq 'A = args[1] >> 32'
     end
   end
 


### PR DESCRIPTION
List of added stuff:
* Add a new "ary" symbol (args_h) to fetch the upper word of a 64-bit seccomp_data argument, (maybe suggest a args_l to complement this?)
* jmp/jump/goto <label> for jump absolute
* Allow <A|X> = len load to load length of seccomp_data struct
* Add some error handling for jumping backwards (don't allow it since Linux's seccomp bpf will not allow it, maybe suggest also implementing a flag that disables these checks?)