### PR TITLE
Allow dumping seccomp filters of existing processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
-dist: trusty
+dist: xenial
+sudo: true
 os:
 - linux
 rvm:
@@ -24,6 +25,12 @@ before_install:
   - gem update --system
   - gem install bundler
   - gem --version
+
+install:
+  - sudo env "PATH=$PATH" bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
+
+script:
+  - sudo env "PATH=$PATH" bundle exec rake
 
 after_script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ $ seccomp-tools dump --help
 #                                      If multiple seccomp syscalls have been invoked (see --limit),
 #                                      results will be written to FILE, FILE_1, FILE_2.. etc.
 #                                      For example, "--output out.bpf" and the output files are out.bpf, out_1.bpf, ...
+#     -p, --pid PID                    Dump seccomp filters of the existing process.
+#                                      You must have CAP_SYS_ADMIN (e.g. be root) in order to use this option.
 
 ```
 
@@ -79,7 +81,7 @@ This work is done by the `ptrace` syscall.
 NOTICE: beware of the execution file will be executed.
 ```bash
 $ file spec/binary/twctf-2016-diary
-# spec/binary/twctf-2016-diary: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/l, for GNU/Linux 2.6.24, BuildID[sha1]=3648e29153ac0259a0b7c3e25537a5334f50107f, not stripped
+# spec/binary/twctf-2016-diary: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.24, BuildID[sha1]=3648e29153ac0259a0b7c3e25537a5334f50107f, not stripped
 
 $ seccomp-tools dump spec/binary/twctf-2016-diary
 #  line  CODE  JT   JF      K

--- a/ext/ptrace/ptrace.c
+++ b/ext/ptrace/ptrace.c
@@ -1,3 +1,5 @@
+#include <errno.h>
+#include <linux/filter.h>
 #include <sys/ptrace.h>
 #include <sys/signal.h>
 
@@ -50,6 +52,39 @@ ptrace_traceme_and_stop(VALUE mod) {
   return Qnil;
 }
 
+static VALUE
+ptrace_attach(VALUE _mod, VALUE pid) {
+  long val = ptrace(PTRACE_ATTACH, NUM2LONG(pid), 0, 0);
+  if(val < 0)
+    rb_sys_fail(0);
+  return Qnil;
+}
+
+static VALUE
+ptrace_seccomp_get_filter(VALUE _mod, VALUE pid, VALUE index) {
+  long count = ptrace(PTRACE_SECCOMP_GET_FILTER, NUM2LONG(pid), NUM2LONG(index), NULL);
+  struct sock_filter *filter;
+  VALUE result;
+  if(count < 0)
+    rb_sys_fail(0);
+  filter = ALLOC_N(struct sock_filter, count);
+  if(ptrace(PTRACE_SECCOMP_GET_FILTER, NUM2LONG(pid), NUM2LONG(index), filter) != count) {
+    xfree(filter);
+    rb_sys_fail(0);
+  }
+  result = rb_str_new((const char *)filter, sizeof(struct sock_filter) * count);
+  xfree(filter);
+  return result;
+}
+
+static VALUE
+ptrace_detach(VALUE _mod, VALUE pid) {
+  long val = ptrace(PTRACE_DETACH, NUM2LONG(pid), 0, 0);
+  if(val < 0)
+    rb_sys_fail(0);
+  return Qnil;
+}
+
 
 void Init_ptrace(void) {
   VALUE mSeccompTools = rb_define_module("SeccompTools");
@@ -79,5 +114,11 @@ void Init_ptrace(void) {
   rb_define_module_function(mPtrace, "traceme", ptrace_traceme, 0);
   /* stop itself before parent attaching */
   rb_define_module_function(mPtrace, "traceme_and_stop", ptrace_traceme_and_stop, 0);
+  /* attach to an existing process */
+  rb_define_module_function(mPtrace, "attach", ptrace_attach, 1);
+  /* retrieve seccomp filter */
+  rb_define_module_function(mPtrace, "seccomp_get_filter", ptrace_seccomp_get_filter, 2);
+  /* detach from an existing process */
+  rb_define_module_function(mPtrace, "detach", ptrace_detach, 1);
 }
 

--- a/spec/cli/dump_spec.rb
+++ b/spec/cli/dump_spec.rb
@@ -13,14 +13,59 @@ describe SeccompTools::CLI::Dump do
     @bin = File.join(@binpath, 'twctf-2016-diary')
     @mul = File.join(@binpath, 'clone_two_seccomp')
     @bpf = IO.binread(File.join(__dir__, '..', 'data', 'twctf-2016-diary.bpf'))
+    @bpf_inspect = <<'EOS'
+"\x20\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x02\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x01\x01\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x3B\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x38\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x39\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x3A\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x55\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x42\x01\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00\x00\x00\xFF\x7F"
+EOS
     SeccompTools::Util.disable_color!
+    @bpf_disasm = SeccompTools::Disasm.disasm(@bpf)
   end
 
   it 'normal' do
-    expect { described_class.new([@bin, '-f', 'inspect']).handle }.to output(<<'EOS').to_stdout
-"\x20\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x02\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x01\x01\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x3B\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x38\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x39\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x3A\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x55\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x15\x00\x00\x01\x42\x01\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00\x00\x00\xFF\x7F"
-EOS
-    expect { described_class.new([@bin]).handle }.to output(SeccompTools::Disasm.disasm(@bpf)).to_stdout
+    expect { described_class.new([@bin, '-f', 'inspect']).handle }.to output(@bpf_inspect).to_stdout
+    expect { described_class.new([@bin]).handle }.to output(@bpf_disasm).to_stdout
+  end
+
+  it 'by pid' do
+    skip 'Must be root' if Process.uid != 0
+    stdin_r, stdin_w = IO.pipe
+    stdout_r, stdout_w = IO.pipe
+    pid = Process.spawn(@bin, in: stdin_r, out: stdout_w)
+    stdout_r.each do |line|
+      break if line.start_with?('Welcome')
+    end
+    expect { described_class.new(['-f', 'inspect', '-p', pid.to_s]).handle }.to output(@bpf_inspect).to_stdout
+    expect { described_class.new(['-l', '2', '-p', pid.to_s]).handle }.to output(@bpf_disasm).to_stdout
+    stdin_w.write("0\n")
+    Process.wait(pid)
+  end
+
+  it 'by pid without root' do
+    skip 'Must be root' if Process.uid != 0
+    pid = Process.spawn('sleep inf')
+    begin
+      error = /PTRACE_SECCOMP_GET_FILTER requires CAP_SYS_ADMIN/
+      dumper_inspect = described_class.new(['-f', 'inspect', '-p', pid.to_s])
+      expect do
+        begin
+          Process::Sys.seteuid('nobody')
+          dumper_inspect.handle
+        ensure
+          Process::Sys.seteuid(0)
+        end
+      end.to terminate.with_code(1).and output(error).to_stderr
+      dumper_disasm = described_class.new(['-p', pid.to_s])
+      expect do
+        begin
+          Process::Sys.seteuid('nobody')
+          dumper_disasm.handle
+        ensure
+          Process::Sys.seteuid(0)
+        end
+      end.to terminate.with_code(1).and output(error).to_stderr
+    ensure
+      Process.kill('TERM', pid)
+      Process.wait(pid)
+    end
   end
 
   it 'output to files' do

--- a/spec/cli/help_spec.rb
+++ b/spec/cli/help_spec.rb
@@ -39,6 +39,8 @@ Usage: seccomp-tools dump [exec] [options]
                                      If multiple seccomp syscalls have been invoked (see --limit),
                                      results will be written to FILE, FILE_1, FILE_2.. etc.
                                      For example, "--output out.bpf" and the output files are out.bpf, out_1.bpf, ...
+    -p, --pid PID                    Dump seccomp filters of the existing process.
+                                     You must have CAP_SYS_ADMIN (e.g. be root) in order to use this option.
 EOS
   end
 

--- a/spec/dumper_spec.rb
+++ b/spec/dumper_spec.rb
@@ -58,7 +58,7 @@ describe SeccompTools::Dumper do
         # there's pid inside seccomp rules.. ignore it
         expect(got.size).to be bpf.size
         expect(got[0, 0x1ec]).to eq bpf[0, 0x1ec]
-        expect(got[0x1ee..-1]).to eq bpf[0x1ee..-1]
+        expect(got[0x1f0..-1]).to eq bpf[0x1f0..-1]
       end
     end
   end


### PR DESCRIPTION
This patch adds -p option to dump subcommand (like the one gdb, strace,
etc support) that uses PTRACE_SECCOMP_GET_FILTER (available since Linux
4.4), which allows dumping seccomp filters of existing processes.