### PR TITLE
Added new seccomp return types

### DIFF
--- a/lib/seccomp-tools/const.rb
+++ b/lib/seccomp-tools/const.rb
@@ -59,6 +59,8 @@ module SeccompTools
         KILL: 0x00000000, # alias of KILL_THREAD
         TRAP: 0x00030000,
         ERRNO: 0x00050000,
+        USER_NOTIF: 0x7fc00000,
+        LOG: 0x7ffc0000,
         TRACE: 0x7ff00000,
         ALLOW: 0x7fff0000
       }.freeze


### PR DESCRIPTION
Comes from
https://github.com/torvalds/linux/blob/489e9fea66f31086f85d9a18e61e4791d94a56a4/include/uapi/linux/seccomp.h#L35-L44