### PR TITLE
Print error message on empty BPF

### DIFF
--- a/lib/seccomp-tools/dumper.rb
+++ b/lib/seccomp-tools/dumper.rb
@@ -181,7 +181,11 @@ module SeccompTools
         while limit.negative? || i < limit
           begin
             bpf = Ptrace.seccomp_get_filter(pid, i)
-          rescue Errno::ENOENT, Errno::EINVAL
+          rescue Errno::EINVAL
+            Logger.error('No seccomp filters installed')
+            break
+          rescue Errno::ENOENT
+            Logger.error('No filter exists at this index')
             break
           end
           collect << (block.nil? ? bpf : yield(bpf, nil))

--- a/spec/cli/dump_spec.rb
+++ b/spec/cli/dump_spec.rb
@@ -34,8 +34,19 @@ EOS
         break if line.start_with?('Welcome')
       end
       expect { described_class.new(['-f', 'inspect', '-p', pid.to_s]).handle }.to output(@bpf_inspect).to_stdout
-      expect { described_class.new(['-l', '2', '-p', pid.to_s]).handle }.to output(@bpf_disasm).to_stdout
+      expect { described_class.new(['-l', '2', '-p', pid.to_s]).handle }.to output(@bpf_disasm+"[ERROR] No filter exists at this index\n").to_stdout
       i.write("0\n")
+    end
+  end
+
+  it 'by pid without filter' do
+    pid = Process.spawn('sleep 60')
+    begin
+      error = /No seccomp filters installed/
+      expect { described_class.new(['-p', pid.to_s]).handle }.to output(error).to_stdout
+    ensure
+      Process.kill('TERM', pid)
+      Process.wait(pid)
     end
   end
 


### PR DESCRIPTION
Apologies in advance if this is unwanted/breaks API, but I just found it nice to know when no seccomp filters were installed. I am not a Ruby dev by profession so this may be wrong (but it works on my machine)