### PR TITLE
Documentation: Add make as build requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ gem install seccomp-tools
 
 If you failed when compiling, try:
 ```
-sudo apt install gcc ruby-dev
+sudo apt install gcc ruby-dev make
 ```
 and install seccomp-tools again.
 

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -31,7 +31,7 @@ $ gem install seccomp-tools
 
 If you failed when compiling, try:
 ```
-sudo apt install gcc ruby-dev
+sudo apt install gcc ruby-dev make
 ```
 and install seccomp-tools again.
 


### PR DESCRIPTION
Up to now `make` is  a silent requirement.
This can be problematic in minimal build environments, e.g. containers, as the documented prerequisite are not sufficient.