### PR TITLE
Explicitly specify logger dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     seccomp-tools (1.6.1)
+      logger
       os (~> 1.1, >= 1.1.1)
 
 GEM
@@ -12,6 +13,7 @@ GEM
     docile (1.4.1)
     json (2.9.0)
     language_server-protocol (3.17.0.3)
+    logger (1.6.5)
     os (1.1.4)
     parallel (1.26.3)
     parser (3.3.6.0)

--- a/seccomp-tools.gemspec
+++ b/seccomp-tools.gemspec
@@ -37,5 +37,6 @@ Visit https://github.com/david942j/seccomp-tools for more details.
   s.add_development_dependency 'simplecov', '~> 0.21'
   s.add_development_dependency 'yard', '~> 0.9'
 
+  s.add_dependency 'logger'
   s.add_dependency 'os', '~> 1.1', '>= 1.1.1'
 end


### PR DESCRIPTION
On Ruby 3.5 the logger gem is no longer shipped with Ruby. Explicitly add the gem dependency to prevent warnings on Ruby 3.4 and errors on Ruby 3.5.

Reference: https://github.com/ruby/ruby/commit/d7e558e3c48c213d0e8bedca4fb547db55613f7c