### PR TITLE
include license and add missing dep

### DIFF
--- a/seccomp-tools.gemspec
+++ b/seccomp-tools.gemspec
@@ -17,7 +17,7 @@ Visit https://github.com/david942j/seccomp-tools for more details.
   s.authors       = ['david942j']
   s.email         = ['david942j@gmail.com']
   s.files         = Dir['lib/**/*.rb'] + Dir['lib/**/*.y'] +
-                    Dir['lib/seccomp-tools/templates/*'] + Dir['bin/*'] + Dir['ext/**/*'] + %w(README.md)
+                    Dir['lib/seccomp-tools/templates/*'] + Dir['bin/*'] + Dir['ext/**/*'] + %w(README.md LICENSE)
   s.extensions    = %w[ext/ptrace/extconf.rb]
   s.executables   = 'seccomp-tools'
 
@@ -39,5 +39,6 @@ Visit https://github.com/david942j/seccomp-tools for more details.
   s.add_development_dependency 'yard', '~> 0.9'
 
   s.add_dependency 'logger'
+  s.add_dependency 'racc', '~> 1.8'
   s.add_dependency 'os', '~> 1.1', '>= 1.1.1'
 end


### PR DESCRIPTION
- including the license in the gem as MIT includes a copyright, it's unique to each gem
- `lib/seccomp-tools.rb` requires `lib/seccomp-tools/asm/asm.rb`
  - which requires `lib/seccomp-tools/asm/compiler.rb`
    - which requires `lib/seccomp-tools/asm/sasm.tab.rb`
      - which requires `racc`.

So even if racc may be unused at runtime because it's transitively required from the root level, the dependency either need must be provided in the gemspec or stop being required from root level.
For example, `tasks/sasm.rake` could `require 'seccomp-tools/asm/sasm.tab'`, `require 'seccomp-tools/asm/compiler'` or `require 'seccomp-tools/asm/asm'` or whatever needed.