### PR TITLE
Make disasm round-trip spec arch-independent

### DIFF
--- a/spec/asm/asm_spec.rb
+++ b/spec/asm/asm_spec.rb
@@ -146,9 +146,13 @@ describe SeccompTools::Asm do
 
   it 'accepts output of disasm' do
     files = Dir.glob('spec/data/*.bpf')
-    files.each do |f|
-      input = SeccompTools::Disasm.disasm(File.binread(f), display_bpf: false, arg_infer: false)
-      expect { described_class.asm(input, arch: :amd64, filename: f) }.to_not raise_error
+    # Disassemble and reassemble under the same arch, otherwise the round-trip depends on the host arch:
+    # syscall names are arch-specific, so names emitted for one arch may not exist in another's table.
+    SeccompTools::Syscall::ABI.each_key do |arch|
+      files.each do |f|
+        input = SeccompTools::Disasm.disasm(File.binread(f), arch:, display_bpf: false, arg_infer: false)
+        expect { described_class.asm(input, arch:, filename: f) }.to_not raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
The spec disassembled with the host arch but reassembled with a hardcoded :amd64. Syscall names are arch-specific, so on a non-amd64 host the round-trip failed: aarch64 names 85 timerfd_create while the amd64 table names 283 timerfd.

Disassemble and reassemble under the same arch, iterating every arch in Syscall::ABI. This removes the host dependency and widens coverage from one arch to all four.