### PR TITLE
Remove clone/vfork TODO in dumper

### DIFF
--- a/lib/seccomp-tools/dumper.rb
+++ b/lib/seccomp-tools/dumper.rb
@@ -120,7 +120,6 @@ module SeccompTools
         child, status = Process.wait2
         @pids << child unless @pids.include?(child)
         cont = true
-        # TODO: Test if clone / vfork works
         if [Ptrace::EVENT_CLONE, Ptrace::EVENT_FORK, Ptrace::EVENT_VFORK].include?(status.to_i >> 16)
           # New child launched!
           # newpid = SeccompTools::Ptrace.geteventmsg(child)


### PR DESCRIPTION
The TODO asked to test whether dumping works for children created via clone / vfork. Verified manually on an aarch64 Linux host with three native C programs, each installing distinguishable filters (a 2-insn filter in the child, then a 1-insn filter in the parent):

- vfork(): child installs a filter then _exit(0); parent installs its own afterwards. Tracer received PTRACE_EVENT_VFORK.
- pthread_create(): the spawned thread installs a filter (per-thread, no TSYNC); main thread installs another after join. Tracer received PTRACE_EVENT_CLONE.
- raw clone() with its own stack and exit signal 0 (non-SIGCHLD): child and parent each install a filter. Tracer received PTRACE_EVENT_CLONE.

Each case was run through Dumper.dump(limit: -1) with Process.wait2 instrumented to record status >> 16, confirming which ptrace event fired. All three returned both filters in installation order. 15 consecutive runs were stable, with no hangs and no leftover processes.

fork() (PTRACE_EVENT_FORK) was already covered by the existing clone_two_seccomp spec.