### PR TITLE
Make dump's -c/--sh-exec take precedence over the positional exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ $ seccomp-tools dump --help
 # dump - Automatically dump seccomp bpf from execution file(s).
 # NOTE : This function is only available on Linux.
 #
-# Usage: seccomp-tools dump [exec] [options]
+# Usage: seccomp-tools dump [EXEC] [options]
 #     -c, --sh-exec <command>          Executes the given command (via sh).
 #                                      Use this option if want to pass arguments or do pipe things to the execution file.
 #                                      e.g. use `-c "./bin > /dev/null"` to dump seccomp without being mixed with stdout.
-#                                      Takes precedence over the [exec] argument.
+#                                      Takes precedence over the [EXEC] argument.
 #     -f, --format FORMAT              Output format. FORMAT can only be one of <disasm|raw|inspect>.
 #                                      Default: disasm
 #     -l, --limit LIMIT                Limit the number of calling "prctl(PR_SET_SECCOMP)".

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ $ seccomp-tools dump --help
 #     -c, --sh-exec <command>          Executes the given command (via sh).
 #                                      Use this option if want to pass arguments or do pipe things to the execution file.
 #                                      e.g. use `-c "./bin > /dev/null"` to dump seccomp without being mixed with stdout.
+#                                      Takes precedence over the [exec] argument.
 #     -f, --format FORMAT              Output format. FORMAT can only be one of <disasm|raw|inspect>.
 #                                      Default: disasm
 #     -l, --limit LIMIT                Limit the number of calling "prctl(PR_SET_SECCOMP)".

--- a/lib/seccomp-tools/cli/dump.rb
+++ b/lib/seccomp-tools/cli/dump.rb
@@ -15,7 +15,7 @@ module SeccompTools
       SUMMARY = 'Automatically dump seccomp bpf from execution file(s).'
       # Usage of this command.
       USAGE = "dump - #{SUMMARY}\nNOTE : This function is only available on Linux." \
-              "\n\nUsage: seccomp-tools dump [exec] [options]".freeze
+              "\n\nUsage: seccomp-tools dump [EXEC] [options]".freeze
 
       # Instantiate a {Dump} object, dumping the first filter as disassembly by default.
       #
@@ -37,7 +37,7 @@ module SeccompTools
           opt.on('-c', '--sh-exec <command>', 'Executes the given command (via sh).',
                  'Use this option if want to pass arguments or do pipe things to the execution file.',
                  'e.g. use `-c "./bin > /dev/null"` to dump seccomp without being mixed with stdout.',
-                 'Takes precedence over the [exec] argument.') do |command|
+                 'Takes precedence over the [EXEC] argument.') do |command|
             option[:command] = command
           end
 
@@ -113,7 +113,7 @@ module SeccompTools
 
       private
 
-      # Warns about positional arguments that are left unused, e.g. an [exec] given together with
+      # Warns about positional arguments that are left unused, e.g. an [EXEC] given together with
       # +-c+, or anything after +--pid+. Dumping still proceeds.
       # @return [void]
       def warn_ignored_arguments

--- a/lib/seccomp-tools/cli/dump.rb
+++ b/lib/seccomp-tools/cli/dump.rb
@@ -36,7 +36,8 @@ module SeccompTools
           opt.banner = usage
           opt.on('-c', '--sh-exec <command>', 'Executes the given command (via sh).',
                  'Use this option if want to pass arguments or do pipe things to the execution file.',
-                 'e.g. use `-c "./bin > /dev/null"` to dump seccomp without being mixed with stdout.') do |command|
+                 'e.g. use `-c "./bin > /dev/null"` to dump seccomp without being mixed with stdout.',
+                 'Takes precedence over the [exec] argument.') do |command|
             option[:command] = command
           end
 
@@ -89,8 +90,10 @@ module SeccompTools
           when :disasm then output { SeccompTools::Disasm.disasm(bpf, arch:) }
           end
         end
+        # -c/--sh-exec takes precedence; a positional exec is used only when -c is absent.
+        option[:command] ||= argv.shift unless option[:pid]
+        warn_ignored_arguments
         if option[:pid].nil?
-          option[:command] = argv.shift unless argv.empty?
           SeccompTools::Dumper.dump('/bin/sh', '-c', option[:command], limit: option[:limit],
                                                                        timeout: option[:timeout], &block)
         else
@@ -106,6 +109,17 @@ module SeccompTools
             exit(1)
           end
         end
+      end
+
+      private
+
+      # Warns about positional arguments that are left unused, e.g. an [exec] given together with
+      # +-c+, or anything after +--pid+. Dumping still proceeds.
+      # @return [void]
+      def warn_ignored_arguments
+        return if argv.empty?
+
+        Logger.warn("ignoring unused argument#{'s' if argv.size > 1}: #{argv.join(' ')}")
       end
     end
   end

--- a/lib/seccomp-tools/logger.rb
+++ b/lib/seccomp-tools/logger.rb
@@ -39,7 +39,12 @@ module SeccompTools
     #   @param [String] msg
     #     The message to be logged.
     #   @return [true]
-    %i[error].each do |sym|
+    # @!method warn(msg)
+    #   Logs +msg+ at the +warn+ severity.
+    #   @param [String] msg
+    #     The message to be logged.
+    #   @return [true]
+    %i[error warn].each do |sym|
       define_method(sym) do |msg|
         logger.__send__(sym, msg)
       end

--- a/spec/cli/dump_spec.rb
+++ b/spec/cli/dump_spec.rb
@@ -82,4 +82,34 @@ EOS
 [ERROR] Dump is only available on Linux.
     EOS
   end
+
+  context 'argument handling' do
+    def stub_dump_capturing_command
+      command = nil
+      allow(SeccompTools::Dumper).to receive(:dump) do |*args, **|
+        command = args[2]
+        []
+      end
+      -> { command }
+    end
+
+    it 'prefers -c over a positional exec and warns about the unused one' do
+      command = stub_dump_capturing_command
+      expect { described_class.new(['-c', 'true', './extra']).handle }
+        .to output("[WARN] ignoring unused argument: ./extra\n").to_stdout
+      expect(command.call).to eq 'true'
+    end
+
+    it 'uses a lone positional exec without warning' do
+      command = stub_dump_capturing_command
+      expect { described_class.new(['./bin']).handle }.not_to output.to_stdout
+      expect(command.call).to eq './bin'
+    end
+
+    it 'warns about positional arguments left after --pid' do
+      allow(SeccompTools::Dumper).to receive(:dump_by_pid).and_return([])
+      expect { described_class.new(['-p', '123', './extra']).handle }
+        .to output("[WARN] ignoring unused argument: ./extra\n").to_stdout
+    end
+  end
 end

--- a/spec/cli/help_spec.rb
+++ b/spec/cli/help_spec.rb
@@ -27,11 +27,11 @@ See 'seccomp-tools <command> --help' to read about a specific subcommand.
 dump - Automatically dump seccomp bpf from execution file(s).
 NOTE : This function is only available on Linux.
 
-Usage: seccomp-tools dump [exec] [options]
+Usage: seccomp-tools dump [EXEC] [options]
     -c, --sh-exec <command>          Executes the given command (via sh).
                                      Use this option if want to pass arguments or do pipe things to the execution file.
                                      e.g. use `-c "./bin > /dev/null"` to dump seccomp without being mixed with stdout.
-                                     Takes precedence over the [exec] argument.
+                                     Takes precedence over the [EXEC] argument.
     -f, --format FORMAT              Output format. FORMAT can only be one of <disasm|raw|inspect>.
                                      Default: disasm
     -l, --limit LIMIT                Limit the number of calling "prctl(PR_SET_SECCOMP)".

--- a/spec/cli/help_spec.rb
+++ b/spec/cli/help_spec.rb
@@ -31,6 +31,7 @@ Usage: seccomp-tools dump [exec] [options]
     -c, --sh-exec <command>          Executes the given command (via sh).
                                      Use this option if want to pass arguments or do pipe things to the execution file.
                                      e.g. use `-c "./bin > /dev/null"` to dump seccomp without being mixed with stdout.
+                                     Takes precedence over the [exec] argument.
     -f, --format FORMAT              Output format. FORMAT can only be one of <disasm|raw|inspect>.
                                      Default: disasm
     -l, --limit LIMIT                Limit the number of calling "prctl(PR_SET_SECCOMP)".


### PR DESCRIPTION
`-c` is the more explicit input, so it should win. When both are given (or anything follows `--pid`) the extra positional is unused; warn about it but proceed. Adds Logger.warn.