### PR TITLE
Fix big-endian (s390x) arg word order

### DIFF
--- a/lib/seccomp-tools/asm/sasm.tab.rb
+++ b/lib/seccomp-tools/asm/sasm.tab.rb
@@ -9,15 +9,22 @@ require 'racc/parser.rb'
 require 'seccomp-tools/asm/scalar'
 require 'seccomp-tools/asm/scanner'
 require 'seccomp-tools/asm/statement'
+require 'seccomp-tools/const'
 
 module SeccompTools
   module Asm
     class SeccompAsmParser < Racc::Parser
 
-module_eval(<<'...end sasm.y/module_eval...', 'sasm.y', 136)
+module_eval(<<'...end sasm.y/module_eval...', 'sasm.y', 137)
   def initialize(scanner)
     @scanner = scanner
     super()
+  end
+
+  # The byte offset of the low (+hi: false+) or high 32-bit word of the 8-byte seccomp_data field
+  # at +base+; on a big-endian target the high word comes first.
+  def word_offset(base, hi:)
+    base + (hi == SeccompTools::Const::Endian.big?(@scanner.arch) ? 0 : 4)
   end
 
   # @return [Array<Statement>]
@@ -632,7 +639,7 @@ module_eval(<<'.,.,', 'sasm.y', 70)
                 off = val[1] == '>>' ? 0 : -1
                 raise_error("operator after an argument can only be '>> 32'", off)
               end
-              val[0] + 4
+              val[0] ^ 4 # the other 32-bit word of the same 64-bit field
 
   end
 .,.,
@@ -665,14 +672,14 @@ module_eval(<<'.,.,', 'sasm.y', 87)
                        idx = val[2].to_i
                    s = val[0]
                    raise_error(format('index of %s[] must between 0 and 5, got %d', s, idx), -1) unless idx.between?(0, 5)
-                   16 + idx * 8 + (s.downcase.end_with?('h') ? 4 : 0)
+                   word_offset(16 + idx * 8, hi: s.downcase.end_with?('h'))
 
   end
 .,.,
 
 module_eval(<<'.,.,', 'sasm.y', 92)
   def _reduce_50(val, _values)
-     8
+     word_offset(8, hi: false)
   end
 .,.,
 

--- a/lib/seccomp-tools/asm/sasm.y
+++ b/lib/seccomp-tools/asm/sasm.y
@@ -72,7 +72,7 @@ rule
                 off = val[1] == '>>' ? 0 : -1
                 raise_error("operator after an argument can only be '>> 32'", off)
               end
-              val[0] + 4
+              val[0] ^ 4 # the other 32-bit word of the same 64-bit field
             }
           | SYS_NUMBER { 0 }
           | ARCH { 4 }
@@ -88,9 +88,9 @@ rule
                    idx = val[2].to_i
                    s = val[0]
                    raise_error(format('index of %s[] must between 0 and 5, got %d', s, idx), -1) unless idx.between?(0, 5)
-                   16 + idx * 8 + (s.downcase.end_with?('h') ? 4 : 0)
+                   word_offset(16 + idx * 8, hi: s.downcase.end_with?('h'))
                  }
-               | INSTRUCTION_POINTER { 8 }
+               | INSTRUCTION_POINTER { word_offset(8, hi: false) }
   args: ARGS
       | ARGS_H
   alu_op_eq: alu_op ASSIGN { val[0] + val[1] }
@@ -131,11 +131,18 @@ end
 require 'seccomp-tools/asm/scalar'
 require 'seccomp-tools/asm/scanner'
 require 'seccomp-tools/asm/statement'
+require 'seccomp-tools/const'
 
 ---- inner
   def initialize(scanner)
     @scanner = scanner
     super()
+  end
+
+  # The byte offset of the low (+hi: false+) or high 32-bit word of the 8-byte seccomp_data field
+  # at +base+; on a big-endian target the high word comes first.
+  def word_offset(base, hi:)
+    base + (hi == SeccompTools::Const::Endian.big?(@scanner.arch) ? 0 : 4)
   end
 
   # @return [Array<Statement>]

--- a/lib/seccomp-tools/asm/scanner.rb
+++ b/lib/seccomp-tools/asm/scanner.rb
@@ -16,6 +16,9 @@ module SeccompTools
       # @return [{Symbol => Integer}]
       #   Syscall name to number, for the architecture this scanner was created with.
       attr_reader :syscalls
+      # @return [Symbol]
+      #   The architecture this scanner was created with.
+      attr_reader :arch
 
       # Keywords with special meanings in our assembly. Keywords are all case-insensitive.
       KEYWORDS = %w[a x if else return mem args args_h data len sys_number arch instruction_pointer].freeze
@@ -55,6 +58,7 @@ module SeccompTools
       def initialize(str, arch, filename: nil)
         @filename = filename || '<inline>'
         @str = str
+        @arch = arch
         @syscalls =
           begin; Const::Syscall.const_get(arch.to_s.upcase); rescue NameError; []; end
         @syscall_all = ARCHES.each_with_object({}) do |ar, memo|

--- a/lib/seccomp-tools/const.rb
+++ b/lib/seccomp-tools/const.rb
@@ -176,9 +176,8 @@ module SeccompTools
     # Endianness constants.
     module Endian
       # +__AUDIT_ARCH_LE+ from +uapi/linux/audit.h+: the bit an +AUDIT_ARCH_*+ value carries iff
-      # the architecture is little-endian. The kernel encodes endianness in the arch token itself —
-      # big-endian variants of biendian CPU families get separate tokens (e.g.
-      # +AUDIT_ARCH_MIPS+/+AUDIT_ARCH_MIPSEL+).
+      # the architecture is little-endian. The kernel encodes endianness in the arch token itself,
+      # so it never needs to be guessed from an architecture's name.
       AUDIT_ARCH_LE = 0x40000000
 
       # Endianness of each architecture as a pack/unpack format modifier, derived from the

--- a/lib/seccomp-tools/const.rb
+++ b/lib/seccomp-tools/const.rb
@@ -175,14 +175,17 @@ module SeccompTools
 
     # Endianness constants.
     module Endian
-      # Defining default endianness of architectures.
-      ENDIAN = {
-        i386: '<',
-        amd64: '<',
-        aarch64: '<',
-        riscv64: '<',
-        s390x: '>'
-      }.freeze
+      # +__AUDIT_ARCH_LE+ from +uapi/linux/audit.h+: the bit an +AUDIT_ARCH_*+ value carries iff
+      # the architecture is little-endian. The kernel encodes endianness in the arch token itself —
+      # big-endian variants of biendian CPU families get separate tokens (e.g.
+      # +AUDIT_ARCH_MIPS+/+AUDIT_ARCH_MIPSEL+).
+      AUDIT_ARCH_LE = 0x40000000
+
+      # Endianness of each architecture as a pack/unpack format modifier, derived from the
+      # {Audit::ARCH} values instead of being maintained by hand.
+      ENDIAN = Audit::ARCH_NAME.transform_values do |name|
+        Audit::ARCH[name].anybits?(AUDIT_ARCH_LE) ? '<' : '>'
+      end.freeze
 
       # Whether +arch+ is big-endian, i.e. stores the high 32-bit word of a 64-bit +seccomp_data+
       # field (+instruction_pointer+ or an argument) first. See +arch_arg_offset_lo/hi+ in

--- a/lib/seccomp-tools/const.rb
+++ b/lib/seccomp-tools/const.rb
@@ -183,6 +183,15 @@ module SeccompTools
         riscv64: '<',
         s390x: '>'
       }.freeze
+
+      # Whether +arch+ is big-endian, i.e. stores the high 32-bit word of a 64-bit +seccomp_data+
+      # field (+instruction_pointer+ or an argument) first. See +arch_arg_offset_lo/hi+ in
+      # libseccomp and the +syscall_arg+ macro of the kernel's seccomp selftests.
+      # @param [Symbol] arch
+      # @return [Boolean]
+      def self.big?(arch)
+        ENDIAN[arch] == '>'
+      end
     end
   end
 end

--- a/lib/seccomp-tools/emulator.rb
+++ b/lib/seccomp-tools/emulator.rb
@@ -25,7 +25,10 @@ module SeccompTools
       @sys_nr = sys_nr
       @args = args
       @ip = instruction_pointer
-      @arch = audit(arch || Util.system_arch)
+      arch ||= Util.system_arch
+      @arch = audit(arch)
+      # On a big-endian architecture the high 32-bit word of a 64-bit field comes first.
+      @big_endian = Const::Endian.big?(arch)
     end
 
     # Run emulation!
@@ -157,12 +160,19 @@ module SeccompTools
       case index
       when 0 then @sys_nr || undefined('sys_number')
       when 1 then @arch || undefined('arch')
-      when 2 then (@ip & 0xffffffff) || undefined('instruction_pointer')
-      when 3 then (@ip >> 32) || undefined('instruction_pointer')
+      when 2, 3 then word_of(@ip || undefined('instruction_pointer'), index)
       else
         val = @args[(index - 4) / 2] || undefined("args[#{(index - 4) / 2}]")
-        (val >> (index.even? ? 0 : 32)) & 0xffffffff
+        word_of(val, index)
       end
+    end
+
+    # The 32-bit word of the 64-bit value +val+ that lives at word-index +index+ of
+    # +seccomp_data+: the high word comes second on little-endian architectures but first on
+    # big-endian ones (s390x).
+    def word_of(val, index)
+      hi = index.odd? ^ @big_endian
+      (val >> (hi ? 32 : 0)) & 0xffffffff
     end
 
     def undefined(var)

--- a/lib/seccomp-tools/instruction/ld.rb
+++ b/lib/seccomp-tools/instruction/ld.rb
@@ -77,8 +77,7 @@ module SeccompTools
         case k
         when 0 then 'sys_number'
         when 4 then 'arch'
-        when 8 then 'instruction_pointer'
-        when 12 then 'instruction_pointer >> 32'
+        when 8, 12 then hi_word?(k) ? 'instruction_pointer >> 32' : 'instruction_pointer'
         else
           idx = Array.new(12) { |i| (i * 4) + 16 }.index(k)
           return 'INVALID' if idx.nil?
@@ -87,8 +86,16 @@ module SeccompTools
         end
       end
 
+      # Is the 32-bit word at byte offset +k+ the high half of its 64-bit +seccomp_data+ field?
+      # The high word comes second on little-endian architectures but first on big-endian ones
+      # (s390x); see +arch_arg_offset_hi+ in libseccomp.
+      def hi_word?(k)
+        (k % 8 == 4) ^ Const::Endian.big?(arch)
+      end
+
       def args_name(idx)
-        default = idx.even? ? "args[#{idx / 2}]" : "args[#{idx / 2}] >> 32"
+        hi = hi_word?((idx * 4) + 16)
+        default = hi ? "args[#{idx / 2}] >> 32" : "args[#{idx / 2}]"
         return default unless show_arg_infer?
 
         sys_nrs = contexts.map { |ctx| ctx.known_data[0] }.uniq
@@ -100,7 +107,7 @@ module SeccompTools
 
         comment = "# #{sys}(#{args.join(', ')})"
         arg_name = Util.colorize(args[idx / 2], t: :args)
-        "#{idx.even? ? arg_name : "#{arg_name} >> 32"} #{Util.colorize(comment, t: :gray)}"
+        "#{hi ? "#{arg_name} >> 32" : arg_name} #{Util.colorize(comment, t: :gray)}"
       end
     end
   end

--- a/spec/asm/asm_spec.rb
+++ b/spec/asm/asm_spec.rb
@@ -151,6 +151,43 @@ describe SeccompTools::Asm do
     EOS
   end
 
+  it 'uses big-endian word order for 64-bit fields on s390x' do
+    # On s390x the high 32-bit word of a 64-bit seccomp_data field comes first (see
+    # arch_arg_offset_lo/hi in libseccomp and syscall_arg in the kernel's seccomp selftests),
+    # so args[2] (its low half) is at offset 0x24 and args[2] >> 32 at 0x20.
+    src = <<-EOS
+      A = args[2]
+      A = args[2] >> 32
+      A = args_h[2]
+      A = instruction_pointer
+      A = instruction_pointer >> 32
+      return ALLOW
+    EOS
+    raw = described_class.asm(src, arch: :s390x)
+    expect(SeccompTools::Disasm.disasm(raw, arch: :s390x)).to eq <<-EOS
+ line  CODE  JT   JF      K
+=================================
+ 0000: 0x20 0x00 0x00 0x00000024  A = args[2]
+ 0001: 0x20 0x00 0x00 0x00000020  A = args[2] >> 32
+ 0002: 0x20 0x00 0x00 0x00000020  A = args[2] >> 32
+ 0003: 0x20 0x00 0x00 0x0000000c  A = instruction_pointer
+ 0004: 0x20 0x00 0x00 0x00000008  A = instruction_pointer >> 32
+ 0005: 0x06 0x00 0x00 0x7fff0000  return ALLOW
+    EOS
+    # ... while a little-endian arch keeps the low half first.
+    raw = described_class.asm(src, arch: :amd64)
+    expect(SeccompTools::Disasm.disasm(raw, arch: :amd64)).to eq <<-EOS
+ line  CODE  JT   JF      K
+=================================
+ 0000: 0x20 0x00 0x00 0x00000020  A = args[2]
+ 0001: 0x20 0x00 0x00 0x00000024  A = args[2] >> 32
+ 0002: 0x20 0x00 0x00 0x00000024  A = args[2] >> 32
+ 0003: 0x20 0x00 0x00 0x00000008  A = instruction_pointer
+ 0004: 0x20 0x00 0x00 0x0000000c  A = instruction_pointer >> 32
+ 0005: 0x06 0x00 0x00 0x7fff0000  return ALLOW
+    EOS
+  end
+
   it 'accepts output of disasm' do
     files = Dir.glob('spec/data/*.bpf')
     # Disassemble and reassemble under the same arch, otherwise the round-trip depends on the host arch:

--- a/spec/const_spec.rb
+++ b/spec/const_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/const'
+
+describe SeccompTools::Const::Endian do
+  it 'derives endianness from the __AUDIT_ARCH_LE bit of the AUDIT_ARCH_* values' do
+    expect(described_class::ENDIAN).to eq(amd64: '<', i386: '<', aarch64: '<', riscv64: '<', s390x: '>')
+    expect(described_class.big?(:s390x)).to be true
+    expect(described_class.big?(:amd64)).to be false
+  end
+end

--- a/spec/emulator_spec.rb
+++ b/spec/emulator_spec.rb
@@ -3,6 +3,7 @@
 
 require 'ostruct'
 
+require 'seccomp-tools/asm/asm'
 require 'seccomp-tools/const'
 require 'seccomp-tools/disasm/disasm'
 require 'seccomp-tools/emulator'
@@ -123,6 +124,53 @@ describe SeccompTools::Emulator do
     it 'kill' do
       expect(described_class.new(@insts, sys_nr: 63, arch: :riscv64).run[:ret]).to be 0x80000000
       expect(described_class.new(@insts, sys_nr: 258, arch: :amd64).run[:ret]).to be 0
+    end
+  end
+
+  context 'big-endian (s390x)' do
+    def insts_of(src, arch)
+      SeccompTools::Disasm.to_bpf(SeccompTools::Asm.asm(src, arch:), arch).map(&:inst)
+    end
+
+    it 'reads the high half of an argument from the first word' do
+      # On s390x data[32] is the HIGH half of args[2] and data[36] the low half.
+      src = <<-EOS
+        A = data[32]
+        A == 0x11223344 ? next : allow
+        A = data[36]
+        A == 0x55667788 ? kill : allow
+      allow:
+        return ALLOW
+      kill:
+        return KILL
+      EOS
+      insts = insts_of(src, :s390x)
+      args = [0, 0, 0x1122334455667788]
+      expect(described_class.new(insts, sys_nr: 4, args:, arch: :s390x).run[:ret]).to be 0
+      # The same value with swapped halves must not match.
+      args = [0, 0, 0x5566778811223344]
+      expect(described_class.new(insts, sys_nr: 4, args:, arch: :s390x).run[:ret]).to be 0x7fff0000
+      # A little-endian arch reads the LOW half at data[32], so the original value must not match.
+      insts = insts_of(src, :amd64)
+      args = [0, 0, 0x1122334455667788]
+      expect(described_class.new(insts, sys_nr: 4, args:, arch: :amd64).run[:ret]).to be 0x7fff0000
+    end
+
+    it 'reads instruction_pointer halves in big-endian order' do
+      # On s390x data[8] holds ip >> 32.
+      src = <<-EOS
+        A = data[8]
+        A == 0xdead ? next : allow
+        A = data[12]
+        A == 0xbeef ? kill : allow
+      allow:
+        return ALLOW
+      kill:
+        return KILL
+      EOS
+      insts = insts_of(src, :s390x)
+      expect(described_class.new(insts, instruction_pointer: 0xdead0000beef, arch: :s390x).run[:ret]).to be 0
+      expect(described_class.new(insts, instruction_pointer: 0xbeef0000dead, arch: :s390x).run[:ret]).to be 0x7fff0000
     end
   end
 end


### PR DESCRIPTION
The endianess was not properly handled on asm and disasm as the index of data[] is different if with different endianness.

Currently only s390x is big-endian so the new test cases focus on it, but the fixes are general and applied to any new big-endian arch in the future.