### PR TITLE
Add SeccompTools::Symbolic BPF execution engine

### DIFF
--- a/lib/seccomp-tools/symbolic/constraint.rb
+++ b/lib/seccomp-tools/symbolic/constraint.rb
@@ -26,12 +26,17 @@ module SeccompTools
         @rhs = rhs
       end
 
-      # Does this constraint hold when {#lhs} takes the concrete value +value+? Only meaningful when
-      # {#rhs} is a constant ({Expr#imm?}); callers use it to test a specific candidate (e.g. "is
-      # this path reachable for architecture X?") and to check a path for self-contradiction.
+      # Does this constraint hold when {#lhs} takes the concrete value +value+? Callers use it to
+      # test a specific candidate (e.g. "is this path reachable for architecture X?") and to check
+      # a path for self-contradiction.
       # @param [Integer] value
       # @return [Boolean]
+      # @raise [ArgumentError]
+      #   When {#rhs} is not a constant ({Expr#imm?}) — there is then no concrete value to compare
+      #   against, so the question cannot be answered.
       def holds?(value)
+        raise ArgumentError, "rhs must be a constant, got #{rhs.kind}" unless rhs.imm?
+
         case op
         when :set then !value.nobits?(rhs.val)
         when :unset then value.nobits?(rhs.val)

--- a/lib/seccomp-tools/symbolic/constraint.rb
+++ b/lib/seccomp-tools/symbolic/constraint.rb
@@ -26,24 +26,6 @@ module SeccompTools
         @rhs = rhs
       end
 
-      # Does this constraint hold when {#lhs} takes the concrete value +value+? Callers use it to
-      # test a specific candidate (e.g. "is this path reachable for architecture X?") and to check
-      # a path for self-contradiction.
-      # @param [Integer] value
-      # @return [Boolean]
-      # @raise [ArgumentError]
-      #   When {#rhs} is not a constant ({Expr#imm?}) — there is then no concrete value to compare
-      #   against, so the question cannot be answered.
-      def holds?(value)
-        raise ArgumentError, "rhs must be a constant, got #{rhs.kind}" unless rhs.imm?
-
-        case op
-        when :set then !value.nobits?(rhs.val)
-        when :unset then value.nobits?(rhs.val)
-        else value.public_send(op, rhs.val) # the comparisons are all Integer methods
-        end
-      end
-
       # A value that uniquely identifies this constraint, for hashing and equality.
       # @return [Array]
       def key

--- a/lib/seccomp-tools/symbolic/constraint.rb
+++ b/lib/seccomp-tools/symbolic/constraint.rb
@@ -10,23 +10,23 @@ module SeccompTools
     # {Executor::Leaf}.
     class Constraint
       # @return [Expr] The left-hand side (what is being tested).
-      attr_reader :expr
+      attr_reader :lhs
       # @return [Symbol] The comparison, one of +:==, :!=, :>, :>=, :<, :<=, :set, :unset+.
       #   +:set+/+:unset+ mean "some/none of these bits are set" (from a +jset+ test).
       attr_reader :op
       # @return [Expr] The right-hand side (what it is compared against).
       attr_reader :rhs
 
-      # @param [Expr] expr
+      # @param [Expr] lhs
       # @param [Symbol] op
       # @param [Expr] rhs
-      def initialize(expr, op, rhs)
-        @expr = expr
+      def initialize(lhs, op, rhs)
+        @lhs = lhs
         @op = op
         @rhs = rhs
       end
 
-      # Does this constraint hold when {#expr} takes the concrete value +value+? Only meaningful when
+      # Does this constraint hold when {#lhs} takes the concrete value +value+? Only meaningful when
       # {#rhs} is a constant ({Expr#imm?}); callers use it to test a specific candidate (e.g. "is
       # this path reachable for architecture X?") and to check a path for self-contradiction.
       # @param [Integer] value
@@ -42,7 +42,7 @@ module SeccompTools
       # A value that uniquely identifies this constraint, for hashing and equality.
       # @return [Array]
       def key
-        [expr.key, op, rhs.key]
+        [lhs.key, op, rhs.key]
       end
     end
   end

--- a/lib/seccomp-tools/symbolic/constraint.rb
+++ b/lib/seccomp-tools/symbolic/constraint.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/symbolic/expr'
+
+module SeccompTools
+  module Symbolic
+    # One fact that must hold for the executor to be on a particular path, e.g. +A == 1+ or
+    # +data[16] & 0xffff != 0+. Every conditional jump adds one {Constraint} to each branch it
+    # takes; the accumulated list is the "path condition" carried in {State#path} and reported on a
+    # {Executor::Leaf}.
+    class Constraint
+      # @return [Expr] The left-hand side (what is being tested).
+      attr_reader :expr
+      # @return [Symbol] The comparison, one of +:==, :!=, :>, :>=, :<, :<=, :set, :unset+.
+      #   +:set+/+:unset+ mean "some/none of these bits are set" (from a +jset+ test).
+      attr_reader :op
+      # @return [Expr] The right-hand side (what it is compared against).
+      attr_reader :rhs
+
+      # @param [Expr] expr
+      # @param [Symbol] op
+      # @param [Expr] rhs
+      def initialize(expr, op, rhs)
+        @expr = expr
+        @op = op
+        @rhs = rhs
+      end
+
+      # Does this constraint hold when {#expr} takes the concrete value +value+? Only meaningful when
+      # {#rhs} is a constant ({Expr#imm?}); callers use it to test a specific candidate (e.g. "is
+      # this path reachable for architecture X?") and to check a path for self-contradiction.
+      # @param [Integer] value
+      # @return [Boolean]
+      def holds?(value)
+        case op
+        when :set then !value.nobits?(rhs.val)
+        when :unset then value.nobits?(rhs.val)
+        else value.public_send(op, rhs.val) # the comparisons are all Integer methods
+        end
+      end
+
+      # A value that uniquely identifies this constraint, for hashing and equality.
+      # @return [Array]
+      def key
+        [expr.key, op, rhs.key]
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/symbolic/executor.rb
+++ b/lib/seccomp-tools/symbolic/executor.rb
@@ -141,7 +141,7 @@ module SeccompTools
         rhs = src == :x ? st.x : Expr.imm(src)
         taken, els = SPLIT[op]
         if st.a.imm? && rhs.imm?
-          j = Constraint.new(st.a, taken, rhs).holds?(st.a.val) ? jt : jf
+          j = concrete_match?(st.a.val, taken, rhs.val) ? jt : jf
           return stack << [pc + j + 1, st]
         end
 
@@ -191,7 +191,7 @@ module SeccompTools
       def cell_feasible?(constraints)
         eqs = constraints.select { |c| c.op == :== }.map { |c| c.rhs.val }.uniq
         return false if eqs.size > 1
-        return constraints.all? { |c| c.holds?(eqs.first) } unless eqs.empty?
+        return constraints.all? { |c| concrete_match?(eqs.first, c.op, c.rhs.val) } unless eqs.empty?
 
         lo = 0
         hi = 0xffffffff
@@ -204,6 +204,17 @@ module SeccompTools
           end
         end
         lo <= hi
+      end
+
+      # Evaluates one comparison concretely: does +value op k+ hold? This is the entire concrete
+      # core the rule-based pruning needs — deliberately far from constraint solving, see
+      # {#feasible?}.
+      def concrete_match?(value, op, k)
+        case op
+        when :set then !value.nobits?(k)
+        when :unset then value.nobits?(k)
+        else value.public_send(op, k) # the comparisons are all Integer methods
+        end
       end
     end
   end

--- a/lib/seccomp-tools/symbolic/executor.rb
+++ b/lib/seccomp-tools/symbolic/executor.rb
@@ -177,8 +177,8 @@ module SeccompTools
       # @param [Array<Constraint>] path
       # @return [Boolean]
       def feasible?(path)
-        path.select { |c| c.expr.plain_data? && c.rhs.imm? }
-            .group_by { |c| c.expr.offset }
+        path.select { |c| c.lhs.plain_data? && c.rhs.imm? }
+            .group_by { |c| c.lhs.offset }
             .all? { |_offset, cs| cell_feasible?(cs) }
       end
 

--- a/lib/seccomp-tools/symbolic/executor.rb
+++ b/lib/seccomp-tools/symbolic/executor.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+require 'set'
+
+require 'seccomp-tools/symbolic/constraint'
+require 'seccomp-tools/symbolic/expr'
+require 'seccomp-tools/symbolic/state'
+
+module SeccompTools
+  module Symbolic
+    # Symbolic executor for classic BPF (the byte-code seccomp filters are written in).
+    #
+    # A normal interpreter (see +SeccompTools::Emulator+) runs a program *once* with concrete inputs
+    # and follows the one path those inputs select. A symbolic executor instead keeps the inputs
+    # *unknown* ({Expr}) and explores **every** path through the program at once. Wherever the
+    # program branches, it walks both sides, remembering on each side the {Constraint} that made
+    # that branch taken. When a path reaches a +return+, the executor records a {Leaf}: the value
+    # returned plus the exact list of conditions that lead there. The collection of leaves is a
+    # complete, input-independent description of what the program does.
+    #
+    # The machine model is classic BPF: two registers (A and X), 16 scratch-memory slots, and a
+    # read-only input buffer addressed by byte offset. Jumps are always forward, so a single walk
+    # with a visited-set terminates and never loops.
+    #
+    # @example
+    #   # instructions come from `SeccompTools::Disasm.to_bpf(raw, arch).map(&:inst)`
+    #   leaves, truncated = SeccompTools::Symbolic::Executor.new(instructions).run
+    #   leaves.first.ret   #=> an Expr describing the returned value
+    #   leaves.first.path  #=> the Array<Constraint> under which it is returned
+    class Executor
+      # A reached +return+: the accumulated path condition, the value returned (an {Expr}), and the
+      # line the +return+ is on.
+      Leaf = Struct.new(:path, :ret, :line)
+
+      # Upper bound on the number of states visited, so a pathological program cannot make the walk
+      # run unboundedly. When hit, {#run} stops early and reports +truncated+.
+      STEP_CAP = 100_000
+
+      # Maps a comparison operator to the pair of {Constraint} operators implied on the taken and
+      # not-taken branches (e.g. a +>=+ test learns +>=+ if taken, +<+ if not).
+      SPLIT = {
+        :== => %i[== !=],
+        :> => %i[> <=],
+        :>= => %i[>= <],
+        :& => %i[set unset]
+      }.freeze
+
+      # @param [Array<Instruction::Base>] instructions
+      #   The program to execute, as +SeccompTools::Disasm.to_bpf(raw, arch).map(&:inst)+. Only the
+      #   duck-typed +#symbolize+ method is used, so any classic-BPF instruction set works.
+      def initialize(instructions)
+        @instructions = instructions
+      end
+
+      # Walks every path and returns the reachable leaves.
+      #
+      # Leaves whose path condition is self-contradictory (e.g. +A == 1+ and +A == 2+ on the same
+      # word) are dropped — a conditional jump forks both ways regardless of feasibility, so the
+      # walk can construct paths that can never happen at runtime. See {#feasible?} for exactly
+      # what can (and deliberately cannot) be proven contradictory.
+      # @return [Array(Array<Leaf>, Boolean)]
+      #   The feasible leaves, and whether the walk was truncated at {STEP_CAP}.
+      def run
+        leaves, truncated = walk
+        [leaves.select { |leaf| feasible?(leaf.path) }, truncated]
+      end
+
+      private
+
+      # Depth-first walk of the control-flow graph. Because jumps are always forward, every successor
+      # line is strictly greater, so the walk terminates; identical +(line, state)+ pairs are
+      # visited once so that re-merging control-flow does not explode.
+      # @return [Array(Array<Leaf>, Boolean)]
+      def walk
+        leaves = []
+        visited = Set.new
+        stack = [[0, State.initial]]
+        steps = 0
+        until stack.empty?
+          return [leaves, true] if steps >= STEP_CAP
+
+          steps += 1
+          pc, st = stack.pop
+          next if pc >= @instructions.size
+          next unless visited.add?([pc, st.signature])
+
+          step(pc, st, leaves, stack)
+        end
+        [leaves, false]
+      end
+
+      # Interprets one instruction symbolically, pushing the successor state(s) onto +stack+ (or
+      # appending a {Leaf} when it is a +return+).
+      def step(pc, st, leaves, stack)
+        op, *args = @instructions[pc].symbolize
+        case op
+        when :ret then leaves << Leaf.new(st.path, args[0] == :a ? st.a : Expr.imm(args[0]), pc)
+        when :ld then stack << [pc + 1, load(st, args[0], args[1])]
+        when :st then stack << [pc + 1, store(st, args[0], args[1])]
+        when :alu then stack << [pc + 1, st.with(a: st.a.apply(args[0], alu_operand(st, args[1])))]
+        when :misc then stack << [pc + 1, args[0] == :txa ? st.with(a: st.x) : st.with(x: st.a)]
+        when :jmp then stack << [pc + args[0] + 1, st]
+        when :cmp then branch_cmp(pc, st, args, stack)
+        end
+      end
+
+      # The right operand of an ALU instruction: the X register, an immediate, or +nil+ for the
+      # unary +neg+ (whose symbolized operand is +nil+).
+      def alu_operand(st, src)
+        return st.x if src == :x
+
+        src && Expr.imm(src)
+      end
+
+      # Loads an immediate, a scratch slot, or a data-buffer word into register A or X.
+      def load(st, dst, src)
+        val = case src[:rel]
+              when :immi then Expr.imm(src[:val])
+              when :mem then st.mem[src[:val]]
+              when :data then Expr.data(src[:val])
+              end
+        dst == :x ? st.with(x: val) : st.with(a: val)
+      end
+
+      # Stores register A or X into a scratch slot.
+      def store(st, reg, idx)
+        mem = st.mem.dup
+        mem[idx] = reg == :x ? st.x : st.a
+        st.with(mem:)
+      end
+
+      # Forks a conditional jump into its taken and not-taken successors, recording the {Constraint}
+      # each branch implies. A comparison between two constants (e.g. against the guaranteed-zero
+      # initial A or X) does not fork: only the branch it actually selects is walked, and no fact
+      # is recorded.
+      def branch_cmp(pc, st, args, stack)
+        op, src, jt, jf = args
+        # jt == jf: the jump is unconditional, so no fact is learned.
+        return stack << [pc + jt + 1, st] if jt == jf
+
+        rhs = src == :x ? st.x : Expr.imm(src)
+        taken, els = SPLIT[op]
+        if st.a.imm? && rhs.imm?
+          j = Constraint.new(st.a, taken, rhs).holds?(st.a.val) ? jt : jf
+          return stack << [pc + j + 1, st]
+        end
+
+        stack << [pc + jt + 1, st.with(path: st.path + [Constraint.new(st.a, taken, rhs)])]
+        stack << [pc + jf + 1, st.with(path: st.path + [Constraint.new(st.a, els, rhs)])]
+      end
+
+      # Is +path+ satisfiable? Deliberately a small rule-based check, not a solver.
+      #
+      # Only facts of the shape "untransformed data word compared to a constant" are examined,
+      # grouped by which word they constrain; any other fact (a transformed word, a comparison
+      # against X, an opaque value) is assumed satisfiable. So an impossible path is never
+      # *wrongly* dropped — the cost of not understanding a fact is noise in the caller's output,
+      # never hidden behavior.
+      #
+      # That fragment is where essentially all real contradictions live. The walk forks every
+      # conditional both ways, so re-merging tests over the same word manufacture impossible
+      # paths: a syscall allow-list behind an x32 range guard yields
+      # +sys >= 0x40000000 && sys == 2+, libseccomp's binary-search dispatch yields the same
+      # equality-versus-range shapes, and sentinel tests yield +sys == 0xffffffff && sys == 2+.
+      # All of these are caught, and since the data words are independent inputs, checking
+      # word-by-word is exact for this fragment, not an approximation: a conjunction of
+      # single-word facts is satisfiable iff each word's facts are.
+      #
+      # What it cannot prove infeasible are contradictions through *derived* values:
+      # +(args[0] & 0xff) == 0x100+ (impossible by masking), wraparound arithmetic like
+      # +args[0] + 1 == 0 && args[0] == 5+, or relations between two transforms of one word
+      # (+sys >> 8 == 1 && sys < 0x100+). Deciding those in general is bit-vector SMT; a filter
+      # convoluted enough to produce them (a deliberately obfuscated challenge, not a seccomp
+      # library) calls for a real solver anyway, so rule-based pruning of that space would add
+      # complexity without making such filters readable. Their paths are kept and rendered with
+      # their full conditions instead.
+      # @param [Array<Constraint>] path
+      # @return [Boolean]
+      def feasible?(path)
+        path.select { |c| c.expr.plain_data? && c.rhs.imm? }
+            .group_by { |c| c.expr.offset }
+            .all? { |_offset, cs| cell_feasible?(cs) }
+      end
+
+      # Are the constraints on a single data word jointly satisfiable? Two different +==+ values
+      # are impossible (+A == 1 && A == 2+). A single +==+ pins the word, so every other fact —
+      # +!=+, the four bounds, and both jset forms — is simply evaluated against it
+      # (+A >= 0x40000000 && A == 2+ dies here). With no +==+, the inequalities must leave a
+      # non-empty range (+A > 10 && A < 5+); +!=+ and jset facts are ignored in that case, since
+      # ruling out a 32-bit word with them alone would take a filter no library generates.
+      def cell_feasible?(constraints)
+        eqs = constraints.select { |c| c.op == :== }.map { |c| c.rhs.val }.uniq
+        return false if eqs.size > 1
+        return constraints.all? { |c| c.holds?(eqs.first) } unless eqs.empty?
+
+        lo = 0
+        hi = 0xffffffff
+        constraints.each do |c|
+          case c.op
+          when :> then lo = [lo, c.rhs.val + 1].max
+          when :>= then lo = [lo, c.rhs.val].max
+          when :< then hi = [hi, c.rhs.val - 1].min
+          when :<= then hi = [hi, c.rhs.val].min
+          end
+        end
+        lo <= hi
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/symbolic/expr.rb
+++ b/lib/seccomp-tools/symbolic/expr.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'seccomp-tools/instruction/alu'
+
 module SeccompTools
   # Generic symbolic execution of classic BPF, with no seccomp knowledge. Where +SeccompTools::Emulator+
   # runs a program once with concrete inputs, the {Executor} here keeps the inputs unknown and walks
@@ -20,8 +22,10 @@ module SeccompTools
     # * {.opaque} - a value we cannot describe (an unsupported operation, or one whose operand is
     #   itself opaque). Nothing can be concluded about it.
     class Expr
-      # ALU operators that {#apply} can represent as a {.binop}. Anything else becomes {.opaque}.
-      REPRESENTABLE = %i[& | ^ << >> + - * /].freeze
+      # ALU operators that {#apply} can represent as a {.binop} — exactly the binary operators
+      # +Instruction::ALU#symbolize+ can produce (its unary +neg+ is handled separately). Anything
+      # else becomes {.opaque}.
+      REPRESENTABLE = Instruction::ALU::OP_SYM.values.freeze
 
       # @return [:imm, :data, :binop, :unop, :opaque] Which kind of expression this is.
       attr_reader :kind

--- a/lib/seccomp-tools/symbolic/expr.rb
+++ b/lib/seccomp-tools/symbolic/expr.rb
@@ -22,9 +22,8 @@ module SeccompTools
     # * {.opaque} - a value we cannot describe (an unsupported operation, or one whose operand is
     #   itself opaque). Nothing can be concluded about it.
     class Expr
-      # ALU operators that {#apply} can represent as a {.binop} — exactly the binary operators
-      # +Instruction::ALU#symbolize+ can produce (its unary +neg+ is handled separately). Anything
-      # else becomes {.opaque}.
+      # The binary ALU operators {#apply} accepts — exactly the ones +Instruction::ALU#symbolize+
+      # can produce (its unary +neg+ is handled separately).
       REPRESENTABLE = Instruction::ALU::OP_SYM.values.freeze
 
       # @return [:imm, :data, :binop, :unop, :opaque] Which kind of expression this is.
@@ -107,18 +106,20 @@ module SeccompTools
       end
 
       # Applies an ALU operation, returning the resulting {Expr}. +neg+ is unary (its operand is
-      # ignored). Two constants fold into a new constant; a {REPRESENTABLE} operation on non-opaque
-      # operands becomes a {.binop}; anything else (an opaque operand) becomes {.opaque}.
+      # ignored). Two constants fold into a new constant; an operation on non-opaque operands
+      # becomes a {.binop}; an opaque operand makes the result {.opaque}.
       # @param [Symbol] op
       #   A Ruby operator symbol as produced by +Instruction::ALU#symbolize+, or +:neg+.
       # @param [Expr, nil] operand
       #   The right operand (+nil+ for the unary +neg+).
       # @return [Expr]
+      # @raise [ArgumentError]
+      #   When +op+ is not one of seccomp's ALU operators (+:neg+ or {REPRESENTABLE}).
       def apply(op, operand)
         return apply_neg if op == :neg
+        raise ArgumentError, "unsupported operator #{op}" unless REPRESENTABLE.include?(op)
         return Expr.opaque if opaque? || operand.opaque?
         return Expr.imm(self.class.fold(val, op, operand.val)) if imm? && operand.imm?
-        return Expr.opaque unless REPRESENTABLE.include?(op)
 
         Expr.binop(op, self, operand)
       end

--- a/lib/seccomp-tools/symbolic/expr.rb
+++ b/lib/seccomp-tools/symbolic/expr.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+module SeccompTools
+  # Generic symbolic execution of classic BPF, with no seccomp knowledge. Where +SeccompTools::Emulator+
+  # runs a program once with concrete inputs, the {Executor} here keeps the inputs unknown and walks
+  # *every* path, reporting each reachable +return+ together with the conditions that lead to it. The
+  # values it manipulates are the {Expr}, {Constraint}, and {State} types; see {Executor} for the
+  # full picture.
+  module Symbolic
+    # A value the executor only knows *symbolically* — that is, without picking concrete inputs.
+    #
+    # Every register and scratch slot in the {State} holds an {Expr}, which is one of:
+    # * {.imm} - a known 32-bit constant, e.g. the result of +A = 5+.
+    # * {.data} - a single word of the input data buffer, at some byte +offset+. Its value is
+    #   unknown; we only remember where it was read from.
+    # * {.binop} - an arithmetic combination of two sub-expressions, e.g. +data[16] & 0xffff+ or even
+    #   +data[16] & data[24]+ (two buffer words combined). This is what lets a caller later describe a
+    #   branch condition faithfully.
+    # * {.unop} - a unary operation on a sub-expression; the only one BPF has is negation (+-A+).
+    # * {.opaque} - a value we cannot describe (an unsupported operation, or one whose operand is
+    #   itself opaque). Nothing can be concluded about it.
+    class Expr
+      # ALU operators that {#apply} can represent as a {.binop}. Anything else becomes {.opaque}.
+      REPRESENTABLE = %i[& | ^ << >> + - * /].freeze
+
+      # @return [:imm, :data, :binop, :unop, :opaque] Which kind of expression this is.
+      attr_reader :kind
+      # @return [Integer?] The constant, when +kind+ is +:imm+.
+      attr_reader :val
+      # @return [Integer?] The byte offset into the input data buffer, when +kind+ is +:data+.
+      attr_reader :offset
+      # @return [Symbol?] The operator, when +kind+ is +:binop+ or +:unop+.
+      attr_reader :op
+      # @return [Expr?] The left and right operands, when +kind+ is +:binop+; a +:unop+ keeps its
+      #   only operand in +lhs+.
+      attr_reader :lhs, :rhs
+
+      # A known constant.
+      # @param [Integer] val
+      # @return [Expr]
+      def self.imm(val)
+        new(:imm, val: val & 0xffffffff)
+      end
+
+      # A single word of the input data buffer.
+      # @param [Integer] offset
+      #   Byte offset into the buffer.
+      # @return [Expr]
+      def self.data(offset)
+        new(:data, offset:)
+      end
+
+      # An arithmetic combination of two expressions.
+      # @param [Symbol] op
+      # @param [Expr] lhs
+      # @param [Expr] rhs
+      # @return [Expr]
+      def self.binop(op, lhs, rhs)
+        new(:binop, op:, lhs:, rhs:)
+      end
+
+      # A unary operation on one expression (its operand is kept in +lhs+).
+      # @param [Symbol] op
+      # @param [Expr] operand
+      # @return [Expr]
+      def self.unop(op, operand)
+        new(:unop, op:, lhs: operand)
+      end
+
+      # A value that cannot be described symbolically.
+      # @return [Expr]
+      def self.opaque
+        new(:opaque)
+      end
+
+      # @param [:imm, :data, :binop, :unop, :opaque] kind
+      # @param [Hash] fields
+      #   The kind-specific fields: +:val+, +:offset+, +:op+, +:lhs+, +:rhs+.
+      def initialize(kind, **fields)
+        @kind = kind
+        @val = fields[:val]
+        @offset = fields[:offset]
+        @op = fields[:op]
+        @lhs = fields[:lhs]
+        @rhs = fields[:rhs]
+      end
+
+      # @return [Boolean]
+      def imm?
+        kind == :imm
+      end
+
+      # Is this a bare data-buffer word (no arithmetic applied)? These are the values a caller can
+      # compare directly against a constant.
+      # @return [Boolean]
+      def plain_data?
+        kind == :data
+      end
+
+      # @return [Boolean]
+      def opaque?
+        kind == :opaque
+      end
+
+      # Applies an ALU operation, returning the resulting {Expr}. +neg+ is unary (its operand is
+      # ignored). Two constants fold into a new constant; a {REPRESENTABLE} operation on non-opaque
+      # operands becomes a {.binop}; anything else (an opaque operand) becomes {.opaque}.
+      # @param [Symbol] op
+      #   A Ruby operator symbol as produced by +Instruction::ALU#symbolize+, or +:neg+.
+      # @param [Expr, nil] operand
+      #   The right operand (+nil+ for the unary +neg+).
+      # @return [Expr]
+      def apply(op, operand)
+        return apply_neg if op == :neg
+        return Expr.opaque if opaque? || operand.opaque?
+        return Expr.imm(self.class.fold(val, op, operand.val)) if imm? && operand.imm?
+        return Expr.opaque unless REPRESENTABLE.include?(op)
+
+        Expr.binop(op, self, operand)
+      end
+
+      # A value that uniquely identifies this expression, for hashing and equality (so the executor
+      # can recognise two states as identical). Sub-expressions are reduced to their own keys, so the
+      # result is a plain nested value.
+      # @return [Array]
+      def key
+        case kind
+        when :binop then [:binop, op, lhs.key, rhs.key]
+        when :unop then [:unop, op, lhs.key]
+        else [kind, val, offset]
+        end
+      end
+
+      # @param [Expr] other
+      # @return [Boolean]
+      def ==(other)
+        other.is_a?(Expr) && key == other.key
+      end
+      alias eql? ==
+
+      # @return [Integer]
+      def hash
+        key.hash
+      end
+
+      # Folds a binary ALU operation on two constants, wrapping to 32 bits (classic BPF is 32-bit).
+      # Every {REPRESENTABLE} operator is a Ruby +Integer+ method, so it applies directly.
+      # @return [Integer]
+      def self.fold(lhs, op, rhs)
+        return 0 if op == :/ && rhs.zero? # a real BPF program is rejected at load for div-by-zero
+        # ... and for shifts of 32+ bits; short-circuit them to their masked result (everything
+        # shifted out) instead of building a needlessly huge integer.
+        return 0 if %i[<< >>].include?(op) && rhs >= 32
+
+        lhs.public_send(op, rhs) & 0xffffffff
+      end
+
+      private
+
+      # The unary negation +A = -A+ (two's complement, 32-bit). Negating a negation cancels — exact
+      # in 32-bit two's complement — instead of stacking into +--x+, which C would even lex as a
+      # decrement.
+      # @return [Expr]
+      def apply_neg
+        return Expr.opaque if opaque?
+        return Expr.imm(self.class.fold(0, :-, val)) if imm?
+        return lhs if kind == :unop # the only unop is :neg
+
+        Expr.unop(:neg, self)
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/symbolic/state.rb
+++ b/lib/seccomp-tools/symbolic/state.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/symbolic/expr'
+
+module SeccompTools
+  module Symbolic
+    # A snapshot of the classic-BPF machine at one point along one path of the walk: the two
+    # registers (A and X), the 16 scratch-memory slots, and the path condition (the {Constraint}s
+    # that must hold to have reached here). The walk fills values in as it interprets
+    # instructions, starting from {.initial}.
+    #
+    # A {State} is treated as immutable — stepping an instruction produces a *new* state via {#with},
+    # so the many paths of the walk can safely share the parts they have in common.
+    class State
+      # @return [Expr] Register A (the accumulator).
+      attr_reader :a
+      # @return [Expr] Register X (the index register).
+      attr_reader :x
+      # @return [Array<Expr>] The 16 scratch-memory slots (+mem[0..15]+).
+      attr_reader :mem
+      # @return [Array<Constraint>] The path condition accumulated so far.
+      attr_reader :path
+
+      # The starting state, as the kernel sets it up: both registers zero (a classic BPF program is
+      # guaranteed +A = X = 0+ on entry — the cBPF-to-eBPF converter clears them first), the
+      # scratch slots unknown, and no facts assumed. The slots stay {Expr.opaque} because nothing
+      # can rely on them: the kernel rejects a filter that reads a slot before writing it.
+      # @return [State]
+      def self.initial
+        new(a: Expr.imm(0), x: Expr.imm(0), mem: Array.new(16, Expr.opaque), path: [])
+      end
+
+      # @param [Expr] a
+      # @param [Expr] x
+      # @param [Array<Expr>] mem
+      # @param [Array<Constraint>] path
+      def initialize(a:, x:, mem:, path:)
+        @a = a
+        @x = x
+        @mem = mem
+        @path = path
+      end
+
+      # Returns a copy with the given fields replaced; unreplaced fields are shared (the state is
+      # immutable).
+      # @return [State]
+      def with(a: @a, x: @x, mem: @mem, path: @path)
+        State.new(a:, x:, mem:, path:)
+      end
+
+      # A value that uniquely identifies this state. The walk uses it to skip a +(line, state)+ pair
+      # it has already visited, which keeps merging control-flow from blowing up.
+      # @return [Array]
+      def signature
+        [a.key, x.key, mem.map(&:key), path.map(&:key)]
+      end
+    end
+  end
+end

--- a/spec/symbolic/constraint_spec.rb
+++ b/spec/symbolic/constraint_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/symbolic/constraint'
+require 'seccomp-tools/symbolic/expr'
+
+describe SeccompTools::Symbolic::Constraint do
+  def expr = SeccompTools::Symbolic::Expr
+
+  def constraint(op, rhs)
+    described_class.new(expr.data(0), op, expr.imm(rhs))
+  end
+
+  describe '#holds?' do
+    it 'evaluates each comparison against a concrete value' do
+      expect(constraint(:==, 5).holds?(5)).to be true
+      expect(constraint(:==, 5).holds?(6)).to be false
+      expect(constraint(:!=, 5).holds?(6)).to be true
+      expect(constraint(:>, 5).holds?(6)).to be true
+      expect(constraint(:>=, 5).holds?(5)).to be true
+      expect(constraint(:<, 5).holds?(4)).to be true
+      expect(constraint(:<=, 5).holds?(5)).to be true
+    end
+
+    it 'evaluates bit tests' do
+      expect(constraint(:set, 0x3).holds?(0x1)).to be true
+      expect(constraint(:set, 0x3).holds?(0x4)).to be false
+      expect(constraint(:unset, 0x3).holds?(0x4)).to be true
+      expect(constraint(:unset, 0x3).holds?(0x1)).to be false
+    end
+  end
+
+  it 'exposes its parts and a hashable key' do
+    c = constraint(:==, 5)
+    expect(c.expr).to eq expr.data(0)
+    expect(c.op).to be :==
+    expect(c.rhs).to eq expr.imm(5)
+    expect(c.key).to eq constraint(:==, 5).key
+  end
+end

--- a/spec/symbolic/constraint_spec.rb
+++ b/spec/symbolic/constraint_spec.rb
@@ -31,7 +31,7 @@ describe SeccompTools::Symbolic::Constraint do
 
   it 'exposes its parts and a hashable key' do
     c = constraint(:==, 5)
-    expect(c.expr).to eq expr.data(0)
+    expect(c.lhs).to eq expr.data(0)
     expect(c.op).to be :==
     expect(c.rhs).to eq expr.imm(5)
     expect(c.key).to eq constraint(:==, 5).key

--- a/spec/symbolic/constraint_spec.rb
+++ b/spec/symbolic/constraint_spec.rb
@@ -6,39 +6,12 @@ require 'seccomp-tools/symbolic/expr'
 describe SeccompTools::Symbolic::Constraint do
   def expr = SeccompTools::Symbolic::Expr
 
-  def constraint(op, rhs)
-    described_class.new(expr.data(0), op, expr.imm(rhs))
-  end
-
-  describe '#holds?' do
-    it 'evaluates each comparison against a concrete value' do
-      expect(constraint(:==, 5).holds?(5)).to be true
-      expect(constraint(:==, 5).holds?(6)).to be false
-      expect(constraint(:!=, 5).holds?(6)).to be true
-      expect(constraint(:>, 5).holds?(6)).to be true
-      expect(constraint(:>=, 5).holds?(5)).to be true
-      expect(constraint(:<, 5).holds?(4)).to be true
-      expect(constraint(:<=, 5).holds?(5)).to be true
-    end
-
-    it 'evaluates bit tests' do
-      expect(constraint(:set, 0x3).holds?(0x1)).to be true
-      expect(constraint(:set, 0x3).holds?(0x4)).to be false
-      expect(constraint(:unset, 0x3).holds?(0x4)).to be true
-      expect(constraint(:unset, 0x3).holds?(0x1)).to be false
-    end
-
-    it 'refuses a non-constant rhs instead of comparing against nil' do
-      c = described_class.new(expr.data(0), :==, expr.data(4))
-      expect { c.holds?(5) }.to raise_error(ArgumentError, /rhs must be a constant, got data/)
-    end
-  end
-
-  it 'exposes its parts and a hashable key' do
-    c = constraint(:==, 5)
+  it 'is a plain value object exposing its parts and a hashable key' do
+    c = described_class.new(expr.data(0), :==, expr.imm(5))
     expect(c.lhs).to eq expr.data(0)
     expect(c.op).to be :==
     expect(c.rhs).to eq expr.imm(5)
-    expect(c.key).to eq constraint(:==, 5).key
+    expect(c.key).to eq described_class.new(expr.data(0), :==, expr.imm(5)).key
+    expect(c.key).not_to eq described_class.new(expr.data(0), :!=, expr.imm(5)).key
   end
 end

--- a/spec/symbolic/constraint_spec.rb
+++ b/spec/symbolic/constraint_spec.rb
@@ -27,6 +27,11 @@ describe SeccompTools::Symbolic::Constraint do
       expect(constraint(:unset, 0x3).holds?(0x4)).to be true
       expect(constraint(:unset, 0x3).holds?(0x1)).to be false
     end
+
+    it 'refuses a non-constant rhs instead of comparing against nil' do
+      c = described_class.new(expr.data(0), :==, expr.data(4))
+      expect { c.holds?(5) }.to raise_error(ArgumentError, /rhs must be a constant, got data/)
+    end
   end
 
   it 'exposes its parts and a hashable key' do

--- a/spec/symbolic/executor_spec.rb
+++ b/spec/symbolic/executor_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/bpf'
+require 'seccomp-tools/const'
+require 'seccomp-tools/disasm/disasm'
+require 'seccomp-tools/instruction/instruction'
+require 'seccomp-tools/symbolic/executor'
+
+describe SeccompTools::Symbolic::Executor do
+  # Assemble a BPF opcode from its named parts, e.g. cmd(:jmp, jmp: :jeq, src: :k).
+  def cmd(command, **parts)
+    c = SeccompTools::Const::BPF
+    maps = { jmp: c::JMP, mode: c::MODE, op: c::OP, misc: c::MISCOP, src: c::SRC }
+    parts.reduce(c::COMMAND[command]) { |code, (key, name)| code | maps[key][name] }
+  end
+
+  def inst(code, jt: 0, jf: 0, k: 0)
+    SeccompTools::BPF.new({ code:, jt:, jf:, k: }, :amd64, 0).inst
+  end
+
+  def run(insts)
+    described_class.new(insts).run
+  end
+
+  def leaves_of(insts)
+    run(insts).first
+  end
+
+  def rets(leaves)
+    leaves.map { |l| l.ret.imm? ? l.ret.val : l.ret.kind }
+  end
+
+  it 'exercises every instruction kind and reaches a return' do
+    insts = [
+      inst(cmd(:ldx, mode: :imm), k: 7),           # X = 7           (ld into X, immediate)
+      inst(cmd(:ld, mode: :abs), k: 0),            # A = data[0]     (ld from data buffer)
+      inst(cmd(:st), k: 3),                        # mem[3] = A
+      inst(cmd(:stx), k: 4),                       # mem[4] = X
+      inst(cmd(:ld, mode: :mem), k: 3),            # A = mem[3]      (ld from scratch)
+      inst(cmd(:ld, mode: :imm), k: 9),            # A = 9           (ld immediate)
+      inst(cmd(:alu, op: :and, src: :k), k: 0xff), # A &= 0xff       (alu, immediate operand)
+      inst(cmd(:alu, op: :add, src: :x)),          # A += X          (alu, X operand)
+      inst(cmd(:misc, misc: :tax)),                # X = A
+      inst(cmd(:misc, misc: :txa)),                # A = X
+      inst(cmd(:jmp, jmp: :ja), k: 0),             # goto next
+      inst(cmd(:ret), k: 0x7fff0000)               # return ALLOW
+    ]
+    leaves, truncated = run(insts)
+    expect(truncated).to be false
+    expect(rets(leaves)).to eq [0x7fff0000]
+    expect(leaves.first.line).to be 11
+  end
+
+  it 'returns the accumulator for `return A`' do
+    leaves, = run([inst(cmd(:ld, mode: :imm), k: 5), inst(cmd(:ret, src: :a))])
+    expect(leaves.first.ret).to eq SeccompTools::Symbolic::Expr.imm(5)
+  end
+
+  it 'starts with the kernel-guaranteed zeroed registers' do
+    # `return A` with A never written returns 0: the kernel clears A and X before a filter runs.
+    leaves, = run([inst(cmd(:ret, src: :a))])
+    expect(leaves.first.ret).to eq SeccompTools::Symbolic::Expr.imm(0)
+  end
+
+  it 'takes only the real branch of a comparison between constants' do
+    insts = [
+      inst(cmd(:jmp, jmp: :jeq, src: :x), jt: 0, jf: 1), # A == X, both are the initial 0
+      inst(cmd(:ret), k: 0x7fff0000),
+      inst(cmd(:ret), k: 0)
+    ]
+    leaves, = run(insts)
+    expect(rets(leaves)).to eq [0x7fff0000]
+    expect(leaves.first.path).to eq [] # a constant comparison teaches nothing
+  end
+
+  it 'collects one leaf per reachable return with its path condition' do
+    raw = File.binread(File.join(__dir__, '..', 'data', 'libseccomp.bpf'))
+    insts = SeccompTools::Disasm.to_bpf(raw, :amd64).map(&:inst)
+    leaves, = run(insts)
+    # write/close/dup/exit -> ALLOW, ERRNO(5) default, KILL (x32 range and non-x86_64)
+    expect(rets(leaves)).to include(0x7fff0000, 0x00050005, 0)
+    allow_leaf = leaves.find { |l| l.ret.val == 0x7fff0000 && l.path.size == 3 }
+    expect(allow_leaf.path.map(&:op)).to include(:==)
+  end
+
+  it 'narrows on a comparison against register X' do
+    insts = [
+      inst(cmd(:ldx, mode: :imm), k: 1),
+      inst(cmd(:ld, mode: :abs), k: 0),
+      inst(cmd(:jmp, jmp: :jeq, src: :x), jt: 0, jf: 1), # if A == X goto next else skip
+      inst(cmd(:ret), k: 0x7fff0000),
+      inst(cmd(:ret), k: 0)
+    ]
+    expect(rets(leaves_of(insts))).to contain_exactly(0x7fff0000, 0)
+  end
+
+  it 'records a data-to-data computation as a binop constraint' do
+    insts = [
+      inst(cmd(:ld, mode: :abs), k: 16),             # A = data[16]
+      inst(cmd(:misc, misc: :tax)),                  # X = data[16]
+      inst(cmd(:ld, mode: :abs), k: 24),             # A = data[24]
+      inst(cmd(:alu, op: :and, src: :x)),            # A = data[24] & data[16]
+      inst(cmd(:jmp, jmp: :jeq), jt: 0, jf: 1, k: 5), # A == 5 -> ALLOW
+      inst(cmd(:ret), k: 0x7fff0000),
+      inst(cmd(:ret), k: 0)
+    ]
+    leaves, = run(insts)
+    expr = leaves.find { |l| l.ret.val == 0x7fff0000 }.path.first.expr
+    expect(expr.kind).to be :binop
+    expect([expr.op, expr.lhs, expr.rhs])
+      .to eq [:&, SeccompTools::Symbolic::Expr.data(24), SeccompTools::Symbolic::Expr.data(16)]
+  end
+
+  it 'handles unary negation without crashing on its nil operand' do
+    insts = [
+      inst(cmd(:ld, mode: :abs), k: 16),             # A = data[16]
+      inst(cmd(:alu, op: :neg)),                     # A = -A
+      inst(cmd(:jmp, jmp: :jeq), jt: 0, jf: 1, k: 5), # -A == 5 -> ALLOW
+      inst(cmd(:ret), k: 0x7fff0000),
+      inst(cmd(:ret), k: 0)
+    ]
+    leaves, = run(insts)
+    expr = leaves.find { |l| l.ret.val == 0x7fff0000 }.path.first.expr
+    expect([expr.kind, expr.op, expr.lhs]).to eq [:unop, :neg, SeccompTools::Symbolic::Expr.data(16)]
+  end
+
+  it 'treats a jump with equal targets as unconditional (no fact learned)' do
+    insts = [
+      inst(cmd(:ld, mode: :abs), k: 0),
+      inst(cmd(:jmp, jmp: :jeq), jt: 1, jf: 1, k: 5), # both branches go to the same line
+      inst(cmd(:ret), k: 0),                          # skipped
+      inst(cmd(:ret), k: 0x7fff0000)
+    ]
+    leaves, = run(insts)
+    expect(rets(leaves)).to eq [0x7fff0000]
+    expect(leaves.first.path).to eq [] # unconditional jump adds no constraint
+  end
+
+  it 'ignores instructions that run off the end of the program' do
+    leaves, = run([inst(cmd(:ld, mode: :abs), k: 0)]) # no return
+    expect(leaves).to eq []
+  end
+
+  it 'reports truncation when the step cap is hit' do
+    stub_const('SeccompTools::Symbolic::Executor::STEP_CAP', 1)
+    _, truncated = run([inst(cmd(:ld, mode: :abs), k: 0), inst(cmd(:ret), k: 0)])
+    expect(truncated).to be true
+  end
+
+  context 'feasibility pruning' do
+    it 'drops a path that requires one word to equal two different values' do
+      # if A == 1 { if A == 2 { ALLOW } }  -- both eqs can never hold together
+      insts = [
+        inst(cmd(:ld, mode: :abs), k: 0),
+        inst(cmd(:jmp, jmp: :jeq), jt: 0, jf: 1, k: 1), # A == 1 -> next, else KILL
+        inst(cmd(:jmp, jmp: :jeq), jt: 1, jf: 0, k: 2), # A == 2 -> ALLOW(line4), else KILL(line3)
+        inst(cmd(:ret), k: 0),
+        inst(cmd(:ret), k: 0x7fff0000)
+      ]
+      expect(rets(leaves_of(insts))).not_to include(0x7fff0000)
+    end
+
+    it 'drops an equality that contradicts an inequality on the same word' do
+      # the only path to ALLOW is `A > 10 && A == 5`, which is impossible
+      insts = [
+        inst(cmd(:ld, mode: :abs), k: 0),
+        inst(cmd(:jmp, jmp: :jgt), jt: 0, jf: 3, k: 10), # A > 10 -> line2, A <= 10 -> KILL(5)
+        inst(cmd(:jmp, jmp: :jeq), jt: 1, jf: 2, k: 5),  # A == 5 -> ALLOW(4), A != 5 -> KILL(5)
+        inst(cmd(:ret), k: 0),                           # line3: unreached
+        inst(cmd(:ret), k: 0x7fff0000),                  # line4: ALLOW (impossible path)
+        inst(cmd(:ret), k: 0)                            # line5: KILL
+      ]
+      expect(rets(leaves_of(insts))).not_to include(0x7fff0000)
+    end
+
+    it 'keeps and drops leaves by whether an inequality range is non-empty' do
+      insts = [
+        inst(cmd(:ld, mode: :abs), k: 0),
+        inst(cmd(:jmp, jmp: :jgt), jt: 1, jf: 0, k: 10), # A > 10 -> line3, A <= 10 -> line2
+        inst(cmd(:ret), k: 0x1111),                      # line2: A <= 10 (covers <=)
+        inst(cmd(:jmp, jmp: :jge), jt: 1, jf: 0, k: 5),  # A >= 5 -> line5, A < 5 -> line4
+        inst(cmd(:ret), k: 0x2222),                      # line4: A > 10 && A < 5 -> impossible (covers <)
+        inst(cmd(:ret), k: 0x3333)                       # line5: A > 10 && A >= 5 (covers >, >=)
+      ]
+      expect(rets(leaves_of(insts))).to contain_exactly(0x1111, 0x3333)
+    end
+  end
+end

--- a/spec/symbolic/executor_spec.rb
+++ b/spec/symbolic/executor_spec.rb
@@ -173,6 +173,18 @@ describe SeccompTools::Symbolic::Executor do
       expect(rets(leaves_of(insts))).not_to include(0x7fff0000)
     end
 
+    it 'evaluates bit tests against a pinned value' do
+      insts = [
+        inst(cmd(:ld, mode: :abs), k: 0),
+        inst(cmd(:jmp, jmp: :jeq), jt: 0, jf: 3, k: 4),  # A == 4 -> next, else KILL
+        inst(cmd(:jmp, jmp: :jset), jt: 0, jf: 1, k: 3), # A & 3 -> ALLOW, else ERRNO
+        inst(cmd(:ret), k: 0x7fff0000),                  # impossible: 4 & 3 == 0
+        inst(cmd(:ret), k: 0x00050001),
+        inst(cmd(:ret), k: 0)
+      ]
+      expect(rets(leaves_of(insts))).to contain_exactly(0x00050001, 0)
+    end
+
     it 'keeps and drops leaves by whether an inequality range is non-empty' do
       insts = [
         inst(cmd(:ld, mode: :abs), k: 0),

--- a/spec/symbolic/executor_spec.rb
+++ b/spec/symbolic/executor_spec.rb
@@ -105,7 +105,7 @@ describe SeccompTools::Symbolic::Executor do
       inst(cmd(:ret), k: 0)
     ]
     leaves, = run(insts)
-    expr = leaves.find { |l| l.ret.val == 0x7fff0000 }.path.first.expr
+    expr = leaves.find { |l| l.ret.val == 0x7fff0000 }.path.first.lhs
     expect(expr.kind).to be :binop
     expect([expr.op, expr.lhs, expr.rhs])
       .to eq [:&, SeccompTools::Symbolic::Expr.data(24), SeccompTools::Symbolic::Expr.data(16)]
@@ -120,7 +120,7 @@ describe SeccompTools::Symbolic::Executor do
       inst(cmd(:ret), k: 0)
     ]
     leaves, = run(insts)
-    expr = leaves.find { |l| l.ret.val == 0x7fff0000 }.path.first.expr
+    expr = leaves.find { |l| l.ret.val == 0x7fff0000 }.path.first.lhs
     expect([expr.kind, expr.op, expr.lhs]).to eq [:unop, :neg, SeccompTools::Symbolic::Expr.data(16)]
   end
 

--- a/spec/symbolic/expr_spec.rb
+++ b/spec/symbolic/expr_spec.rb
@@ -73,7 +73,11 @@ describe SeccompTools::Symbolic::Expr do
     end
 
     it 'negates via a unary node, folding a constant' do
+      # Ruby bitwise ops act on two's complement, so masking a negative gives the 32-bit value.
       expect(described_class.imm(5).apply(:neg, nil).val).to be 0xfffffffb # -5, two's complement
+      expect(described_class.imm(1).apply(:neg, nil).val).to be 0xffffffff
+      expect(described_class.imm(0).apply(:neg, nil).val).to be 0
+      expect(described_class.imm(0x80000000).apply(:neg, nil).val).to be 0x80000000 # its own negation
       neg = described_class.data(0).apply(:neg, nil)
       expect([neg.kind, neg.op, neg.lhs]).to eq [:unop, :neg, described_class.data(0)]
       expect(described_class.opaque.apply(:neg, nil).opaque?).to be true

--- a/spec/symbolic/expr_spec.rb
+++ b/spec/symbolic/expr_spec.rb
@@ -85,10 +85,16 @@ describe SeccompTools::Symbolic::Expr do
       expect(e.apply(:neg, nil).apply(:neg, nil)).to eq e
     end
 
-    it 'becomes opaque for an opaque operand, an opaque base, and unrepresentable ops' do
+    it 'becomes opaque for an opaque operand or an opaque base' do
       expect(described_class.data(16).apply(:+, described_class.opaque).opaque?).to be true
       expect(described_class.opaque.apply(:+, described_class.imm(1)).opaque?).to be true
-      expect(described_class.data(16).apply(:%, described_class.imm(2)).opaque?).to be true
+    end
+
+    it 'rejects an operator seccomp has no ALU instruction for, regardless of operand kinds' do
+      expect { described_class.data(16).apply(:%, described_class.imm(2)) }
+        .to raise_error(ArgumentError, /unsupported operator %/)
+      expect { described_class.imm(6).apply(:%, described_class.imm(2)) }
+        .to raise_error(ArgumentError, /unsupported operator %/)
     end
   end
 

--- a/spec/symbolic/expr_spec.rb
+++ b/spec/symbolic/expr_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/symbolic/expr'
+
+describe SeccompTools::Symbolic::Expr do
+  describe 'kinds' do
+    it 'imm' do
+      e = described_class.imm(0x1_0000_0005) # wraps to 32 bits
+      expect(e.imm?).to be true
+      expect(e.opaque?).to be false
+      expect(e.plain_data?).to be false
+      expect(e.val).to be 5
+    end
+
+    it 'data' do
+      e = described_class.data(16)
+      expect(e.plain_data?).to be true
+      expect(e.offset).to be 16
+    end
+
+    it 'opaque' do
+      expect(described_class.opaque.opaque?).to be true
+    end
+  end
+
+  describe '#apply' do
+    it 'folds two constants' do
+      expect(described_class.imm(6).apply(:+, described_class.imm(7)).val).to be 13
+    end
+
+    it 'folds shifts and masks to 32 bits' do
+      expect(described_class.imm(1).apply(:<<, described_class.imm(4)).val).to be 0x10
+      expect(described_class.imm(0x100).apply(:>>, described_class.imm(4)).val).to be 0x10
+      expect(described_class.imm(0xffffffff).apply(:+, described_class.imm(2)).val).to be 1
+    end
+
+    it 'short-circuits shifts of 32+ bits to zero without building a huge integer' do
+      # The kernel rejects such shifts at load; 0 is what masking the shifted-out value gives.
+      expect(described_class.imm(1).apply(:<<, described_class.imm(0xffffffff)).val).to be 0
+      expect(described_class.imm(1).apply(:<<, described_class.imm(32)).val).to be 0
+      expect(described_class.imm(0xffffffff).apply(:>>, described_class.imm(32)).val).to be 0
+    end
+
+    it 'treats division by zero as zero' do
+      expect(described_class.imm(6).apply(:/, described_class.imm(0)).val).to be 0
+      expect(described_class.imm(6).apply(:/, described_class.imm(2)).val).to be 3
+    end
+
+    it 'builds a binop for a data word combined with a constant' do
+      e = described_class.data(16).apply(:&, described_class.imm(0xffff))
+      expect(e.plain_data?).to be false
+      expect(e.kind).to be :binop
+      expect(e.op).to be :&
+      expect(e.lhs).to eq described_class.data(16)
+      expect(e.rhs).to eq described_class.imm(0xffff)
+    end
+
+    it 'builds a binop for two data words' do
+      e = described_class.data(32).apply(:|, described_class.data(16))
+      expect([e.kind, e.op, e.lhs, e.rhs])
+        .to eq [:binop, :|, described_class.data(32), described_class.data(16)]
+    end
+
+    it 'builds a binop rooted at a constant (immediate & data)' do
+      e = described_class.imm(0x1337).apply(:&, described_class.data(0))
+      expect([e.kind, e.op, e.lhs, e.rhs])
+        .to eq [:binop, :&, described_class.imm(0x1337), described_class.data(0)]
+    end
+
+    it 'builds a binop for division' do
+      e = described_class.data(0).apply(:/, described_class.imm(2))
+      expect([e.kind, e.op, e.lhs, e.rhs]).to eq [:binop, :/, described_class.data(0), described_class.imm(2)]
+    end
+
+    it 'negates via a unary node, folding a constant' do
+      expect(described_class.imm(5).apply(:neg, nil).val).to be 0xfffffffb # -5, two's complement
+      neg = described_class.data(0).apply(:neg, nil)
+      expect([neg.kind, neg.op, neg.lhs]).to eq [:unop, :neg, described_class.data(0)]
+      expect(described_class.opaque.apply(:neg, nil).opaque?).to be true
+    end
+
+    it 'cancels a double negation' do
+      expect(described_class.data(0).apply(:neg, nil).apply(:neg, nil)).to eq described_class.data(0)
+      e = described_class.data(0).apply(:+, described_class.data(4))
+      expect(e.apply(:neg, nil).apply(:neg, nil)).to eq e
+    end
+
+    it 'becomes opaque for an opaque operand, an opaque base, and unrepresentable ops' do
+      expect(described_class.data(16).apply(:+, described_class.opaque).opaque?).to be true
+      expect(described_class.opaque.apply(:+, described_class.imm(1)).opaque?).to be true
+      expect(described_class.data(16).apply(:%, described_class.imm(2)).opaque?).to be true
+    end
+  end
+
+  describe 'equality and hashing' do
+    it 'compares by content, recursing into binops' do
+      expect(described_class.data(16)).to eq described_class.data(16)
+      expect(described_class.data(16)).not_to eq described_class.data(20)
+      expect(described_class.imm(5)).not_to eq 5 # non-Expr
+      a = described_class.data(0).apply(:&, described_class.imm(1))
+      b = described_class.data(0).apply(:&, described_class.imm(1))
+      c = described_class.data(0).apply(:&, described_class.imm(2))
+      expect(a).to eq b
+      expect(a).not_to eq c
+      expect(a.eql?(b)).to be true
+      expect(described_class.data(0).apply(:neg, nil)).to eq described_class.data(0).apply(:neg, nil)
+    end
+
+    it 'hashes equal expressions alike' do
+      expect(described_class.imm(5).hash).to eq described_class.imm(5).hash
+      e = described_class.data(0).apply(:&, described_class.imm(1))
+      expect({ e => 1 }[described_class.data(0).apply(:&, described_class.imm(1))]).to be 1
+    end
+  end
+end

--- a/spec/symbolic/state_spec.rb
+++ b/spec/symbolic/state_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/symbolic/state'
+
+describe SeccompTools::Symbolic::State do
+  it 'starts with zeroed registers (the kernel guarantee), opaque scratch slots and an empty path' do
+    st = described_class.initial
+    expect(st.a).to eq SeccompTools::Symbolic::Expr.imm(0)
+    expect(st.x).to eq SeccompTools::Symbolic::Expr.imm(0)
+    expect(st.mem.size).to be 16
+    expect(st.mem).to all(satisfy(&:opaque?))
+    expect(st.path).to eq []
+  end
+
+  it 'copies with a field replaced, sharing the rest' do
+    st = described_class.initial
+    imm = SeccompTools::Symbolic::Expr.imm(5)
+    st2 = st.with(a: imm)
+    expect(st2.a).to eq imm
+    expect(st2.x).to be st.x # shared
+    expect(st.a.val).to be 0 # original untouched
+  end
+
+  it 'has a signature that reflects its contents' do
+    st = described_class.initial
+    expect(st.signature).to eq described_class.initial.signature
+    expect(st.with(a: SeccompTools::Symbolic::Expr.imm(5)).signature).not_to eq st.signature
+  end
+end


### PR DESCRIPTION
A generic symbolic executor for classic BPF: Expr/Constraint/State and
an Executor that walks every path and returns each reachable return
with its path condition, pruning infeasible paths. Models the kernel-
guaranteed zeroed initial registers and folds constant branches.
Nothing uses it yet.