### PR TITLE
Use Const::BPF::SeccompData across disasm, emu and asm

### DIFF
--- a/lib/seccomp-tools/asm/sasm.tab.rb
+++ b/lib/seccomp-tools/asm/sasm.tab.rb
@@ -15,7 +15,7 @@ module SeccompTools
   module Asm
     class SeccompAsmParser < Racc::Parser
 
-module_eval(<<'...end sasm.y/module_eval...', 'sasm.y', 137)
+module_eval(<<'...end sasm.y/module_eval...', 'sasm.y', 138)
   def initialize(scanner)
     @scanner = scanner
     super()
@@ -646,40 +646,41 @@ module_eval(<<'.,.,', 'sasm.y', 70)
 
 module_eval(<<'.,.,', 'sasm.y', 76)
   def _reduce_46(val, _values)
-     0
+     SeccompTools::Const::BPF::SeccompData::SYS_NUMBER
   end
 .,.,
 
 module_eval(<<'.,.,', 'sasm.y', 77)
   def _reduce_47(val, _values)
-     4
+     SeccompTools::Const::BPF::SeccompData::ARCH
   end
 .,.,
 
 module_eval(<<'.,.,', 'sasm.y', 79)
   def _reduce_48(val, _values)
                   idx = val[2].to_i
-              if idx % 4 != 0 || idx >= 64
-                raise_error(format('index of data[] must be a multiple of 4 and less than 64, got %d', idx), -1)
+              size = SeccompTools::Const::BPF::SeccompData::SIZE
+              if idx % 4 != 0 || idx >= size
+                raise_error(format('index of data[] must be a multiple of 4 and less than %d, got %d', size, idx), -1)
               end
               idx
 
   end
 .,.,
 
-module_eval(<<'.,.,', 'sasm.y', 87)
+module_eval(<<'.,.,', 'sasm.y', 88)
   def _reduce_49(val, _values)
                        idx = val[2].to_i
                    s = val[0]
                    raise_error(format('index of %s[] must between 0 and 5, got %d', s, idx), -1) unless idx.between?(0, 5)
-                   word_offset(16 + idx * 8, hi: s.downcase.end_with?('h'))
+                   word_offset(SeccompTools::Const::BPF::SeccompData::ARGS + idx * 8, hi: s.downcase.end_with?('h'))
 
   end
 .,.,
 
-module_eval(<<'.,.,', 'sasm.y', 92)
+module_eval(<<'.,.,', 'sasm.y', 93)
   def _reduce_50(val, _values)
-     word_offset(8, hi: false)
+     word_offset(SeccompTools::Const::BPF::SeccompData::INSTRUCTION_POINTER, hi: false)
   end
 .,.,
 
@@ -687,7 +688,7 @@ module_eval(<<'.,.,', 'sasm.y', 92)
 
 # reduce 52 omitted
 
-module_eval(<<'.,.,', 'sasm.y', 95)
+module_eval(<<'.,.,', 'sasm.y', 96)
   def _reduce_53(val, _values)
      val[0] + val[1]
   end
@@ -697,13 +698,13 @@ module_eval(<<'.,.,', 'sasm.y', 95)
 
 # reduce 55 omitted
 
-module_eval(<<'.,.,', 'sasm.y', 98)
+module_eval(<<'.,.,', 'sasm.y', 99)
   def _reduce_56(val, _values)
      Scalar::ConstVal.new(val[0] & 0xffffffff)
   end
 .,.,
 
-module_eval(<<'.,.,', 'sasm.y', 99)
+module_eval(<<'.,.,', 'sasm.y', 100)
   def _reduce_57(val, _values)
      val[1]
   end
@@ -713,37 +714,37 @@ module_eval(<<'.,.,', 'sasm.y', 99)
 
 # reduce 59 omitted
 
-module_eval(<<'.,.,', 'sasm.y', 102)
+module_eval(<<'.,.,', 'sasm.y', 103)
   def _reduce_60(val, _values)
      Scalar::A.instance
   end
 .,.,
 
-module_eval(<<'.,.,', 'sasm.y', 103)
+module_eval(<<'.,.,', 'sasm.y', 104)
   def _reduce_61(val, _values)
      Scalar::X.instance
   end
 .,.,
 
-module_eval(<<'.,.,', 'sasm.y', 104)
+module_eval(<<'.,.,', 'sasm.y', 105)
   def _reduce_62(val, _values)
      val[0].to_i
   end
 .,.,
 
-module_eval(<<'.,.,', 'sasm.y', 105)
+module_eval(<<'.,.,', 'sasm.y', 106)
   def _reduce_63(val, _values)
      val[0].to_i(16)
   end
 .,.,
 
-module_eval(<<'.,.,', 'sasm.y', 106)
+module_eval(<<'.,.,', 'sasm.y', 107)
   def _reduce_64(val, _values)
      Const::Audit::ARCH[val[0]]
   end
 .,.,
 
-module_eval(<<'.,.,', 'sasm.y', 108)
+module_eval(<<'.,.,', 'sasm.y', 109)
   def _reduce_65(val, _values)
                 s = val[0]
             return @scanner.syscalls[s.to_sym] unless s.include?('.')

--- a/lib/seccomp-tools/asm/sasm.y
+++ b/lib/seccomp-tools/asm/sasm.y
@@ -74,12 +74,13 @@ rule
               end
               val[0] ^ 4 # the other 32-bit word of the same 64-bit field
             }
-          | SYS_NUMBER { 0 }
-          | ARCH { 4 }
+          | SYS_NUMBER { SeccompTools::Const::BPF::SeccompData::SYS_NUMBER }
+          | ARCH { SeccompTools::Const::BPF::SeccompData::ARCH }
           | DATA LBRACK constexpr RBRACK {
               idx = val[2].to_i
-              if idx % 4 != 0 || idx >= 64
-                raise_error(format('index of data[] must be a multiple of 4 and less than 64, got %d', idx), -1)
+              size = SeccompTools::Const::BPF::SeccompData::SIZE
+              if idx % 4 != 0 || idx >= size
+                raise_error(format('index of data[] must be a multiple of 4 and less than %d, got %d', size, idx), -1)
               end
               idx
             }
@@ -88,9 +89,9 @@ rule
                    idx = val[2].to_i
                    s = val[0]
                    raise_error(format('index of %s[] must between 0 and 5, got %d', s, idx), -1) unless idx.between?(0, 5)
-                   word_offset(16 + idx * 8, hi: s.downcase.end_with?('h'))
+                   word_offset(SeccompTools::Const::BPF::SeccompData::ARGS + idx * 8, hi: s.downcase.end_with?('h'))
                  }
-               | INSTRUCTION_POINTER { word_offset(8, hi: false) }
+               | INSTRUCTION_POINTER { word_offset(SeccompTools::Const::BPF::SeccompData::INSTRUCTION_POINTER, hi: false) }
   args: ARGS
       | ARGS_H
   alu_op_eq: alu_op ASSIGN { val[0] + val[1] }

--- a/lib/seccomp-tools/const.rb
+++ b/lib/seccomp-tools/const.rb
@@ -5,8 +5,32 @@ module SeccompTools
   module Const
     # For BPF / seccomp.
     module BPF
+      # Byte offsets of the fields of the filter's input buffer:
+      #   struct seccomp_data {
+      #     int nr;                     // SYS_NUMBER
+      #     __u32 arch;                 // ARCH
+      #     __u64 instruction_pointer;  // INSTRUCTION_POINTER
+      #     __u64 args[6];              // ARGS
+      #   };
+      # The 64-bit fields are each two 32-bit words a filter loads separately (see {QWORD_BASES}).
+      module SeccompData
+        # Byte offset of the syscall number.
+        SYS_NUMBER = 0
+        # Byte offset of the architecture.
+        ARCH = 4
+        # Byte offset of the instruction pointer.
+        INSTRUCTION_POINTER = 8
+        # Byte offset of the first 64-bit argument.
+        ARGS = 16
+        # Total size in bytes; the +len+ load returns this.
+        SIZE = 64
+        # Byte offsets of the 64-bit fields (+instruction_pointer+ and the six arguments), each a
+        # pair of 32-bit words.
+        QWORD_BASES = [INSTRUCTION_POINTER, *(ARGS...SIZE).step(8)].freeze
+      end
+
       # sizeof(struct seccomp_data)
-      SIZEOF_SECCOMP_DATA = 64
+      SIZEOF_SECCOMP_DATA = SeccompData::SIZE
 
       # option set seccomp
       PR_SET_SECCOMP = 22

--- a/lib/seccomp-tools/emulator.rb
+++ b/lib/seccomp-tools/emulator.rb
@@ -154,7 +154,8 @@ module SeccompTools
     end
 
     def data_of(index)
-      raise IndexError, "Invalid index: #{index}" unless index.nobits?(3) && index.between?(0, 63)
+      max = Const::BPF::SeccompData::SIZE - 1
+      raise IndexError, "Invalid index: #{index}" unless index.nobits?(3) && index.between?(0, max)
 
       index /= 4
       case index

--- a/lib/seccomp-tools/instruction/ld.rb
+++ b/lib/seccomp-tools/instruction/ld.rb
@@ -74,12 +74,14 @@ module SeccompTools
       #   __u64 args[6];
       # };
       def seccomp_data_str
+        data = Const::BPF::SeccompData
         case k
-        when 0 then 'sys_number'
-        when 4 then 'arch'
-        when 8, 12 then hi_word?(k) ? 'instruction_pointer >> 32' : 'instruction_pointer'
+        when data::SYS_NUMBER then 'sys_number'
+        when data::ARCH then 'arch'
+        when data::INSTRUCTION_POINTER, data::INSTRUCTION_POINTER + 4
+          hi_word?(k) ? 'instruction_pointer >> 32' : 'instruction_pointer'
         else
-          idx = Array.new(12) { |i| (i * 4) + 16 }.index(k)
+          idx = (data::ARGS...data::SIZE).step(4).to_a.index(k)
           return 'INVALID' if idx.nil?
 
           args_name(idx)
@@ -94,7 +96,7 @@ module SeccompTools
       end
 
       def args_name(idx)
-        hi = hi_word?((idx * 4) + 16)
+        hi = hi_word?((idx * 4) + Const::BPF::SeccompData::ARGS)
         default = hi ? "args[#{idx / 2}] >> 32" : "args[#{idx / 2}]"
         return default unless show_arg_infer?
 


### PR DESCRIPTION
The struct seccomp_data field offsets (0, 4, 8, 16, size 64) were hardcoded in ld.rb, emulator.rb and the asm grammar. Reference the canonical Const::BPF::SeccompData layout instead. (The constant itself also lands via the explain branch; identical definition here so this branch stands alone.)