### PR TITLE
Name disasm arguments by the inferred arch, not the declared one

### DIFF
--- a/lib/seccomp-tools/instruction/base.rb
+++ b/lib/seccomp-tools/instruction/base.rb
@@ -62,6 +62,18 @@ module SeccompTools
 
       private
 
+      # The architecture this instruction's operands should be read as: the one the filter has
+      # branched on (+arch == AUDIT_ARCH_*+) when the context pins a single value, else +nil+ so
+      # callers fall back to the declared {#arch}. Lets syscall/argument names stay correct even
+      # when the filter is disassembled under a different +--arch+ than it targets.
+      # @return [Symbol?]
+      def infer_arch
+        arches = contexts.map { |ctx| ctx.known_data[4] }.uniq
+        return nil unless arches.size == 1 && !arches.first.nil?
+
+        Const::Audit.arch_symbol(arches.first)
+      end
+
       # Delegate the accessors of the wrapped {SeccompTools::BPF} so subclasses can use them directly.
       %i(code jt jf k arch line contexts show_arg_infer?).each do |sym|
         define_method(sym) do

--- a/lib/seccomp-tools/instruction/jmp.rb
+++ b/lib/seccomp-tools/instruction/jmp.rb
@@ -95,15 +95,6 @@ module SeccompTools
         a == arch ? name : "#{a}.#{name}"
       end
 
-      # Infers the architecture from context.
-      # @return [Symbol?]
-      def infer_arch
-        arches = contexts.map { |ctx| ctx.known_data[4] }.uniq
-        return nil unless arches.size == 1 && !arches.first.nil?
-
-        Const::Audit.arch_symbol(arches.first)
-      end
-
       def src
         SRC.invert[code & 8] == :x ? :x : k
       end

--- a/lib/seccomp-tools/instruction/ld.rb
+++ b/lib/seccomp-tools/instruction/ld.rb
@@ -103,11 +103,13 @@ module SeccompTools
         sys_nrs = contexts.map { |ctx| ctx.known_data[0] }.uniq
         return default if sys_nrs.size != 1 || sys_nrs.first.nil?
 
-        sys = Const::Syscall.const_get(arch.upcase.to_sym).invert[sys_nrs.first]
+        a = infer_arch || arch
+        sys = Const::Syscall.const_get(a.upcase.to_sym).invert[sys_nrs.first]
         args = Const::SYS_ARG[sys]
         return default if args.nil? || args[idx / 2].nil? # function prototype doesn't have that argument
 
-        comment = "# #{sys}(#{args.join(', ')})"
+        name = a == arch ? sys : "#{a}.#{sys}"
+        comment = "# #{name}(#{args.join(', ')})"
         arg_name = Util.colorize(args[idx / 2], t: :args)
         "#{hi ? "#{arg_name} >> 32" : arg_name} #{Util.colorize(comment, t: :gray)}"
       end

--- a/spec/disasm/disasm_spec.rb
+++ b/spec/disasm/disasm_spec.rb
@@ -1,6 +1,7 @@
 # encoding: ascii-8bit
 # frozen_string_literal: true
 
+require 'seccomp-tools/asm/asm'
 require 'seccomp-tools/disasm/disasm'
 require 'seccomp-tools/util'
 
@@ -484,5 +485,25 @@ describe SeccompTools::Disasm do
  0027: 0x06 0x00 0x00 0x00000000  return KILL
  0028: 0x06 0x00 0x00 0x7fff0000  return ALLOW
     EOS
+  end
+
+  it 'names arguments by the filter-inferred arch, not the declared one' do
+    # Assembled for amd64 but disassembled as aarch64. The `arch == X86_64` check lets disasm infer
+    # amd64, so syscall 1 and its arguments must read as amd64.write(fd, ...) — the same inference
+    # the jump line already uses — and not the aarch64 syscall 1 (io_destroy(ctx)).
+    src = <<-EOS
+      A = arch
+      A == ARCH_X86_64 ? next : dead
+      A = sys_number
+      A == write ? chk : dead
+    chk:
+      A = args[0]
+      return ALLOW
+    dead:
+      return KILL
+    EOS
+    out = described_class.disasm(SeccompTools::Asm.asm(src, arch: :amd64), arch: :aarch64)
+    expect(out).to include('if (A != amd64.write) goto')
+    expect(out).to include('A = fd # amd64.write(fd, buf, count)')
   end
 end


### PR DESCRIPTION
ld.rb resolved the syscall for argument names via the declared --arch, while jmp.rb already used the arch the filter branches on. So a filter assembled for amd64 but disassembled as aarch64 showed the jump as amd64.write yet its argument as io_destroy(ctx). Move infer_arch to Instruction::Base and have args_name use infer_arch || arch, matching the jump line.