### PR TITLE
Share the seccomp action-label decoder, fixing disasm ret_str

### DIFF
--- a/lib/seccomp-tools/const.rb
+++ b/lib/seccomp-tools/const.rb
@@ -128,6 +128,24 @@ module SeccompTools
         tax: 0x00,
         txa: 0x80
       }.freeze
+
+      # The action a seccomp return +value+ names, e.g. +"ALLOW"+ or +"ERRNO(5)"+, or +nil+ when
+      # the action bits are not a value the kernel defines. The data part is shown for the actions
+      # that consume it: +ERRNO+ always, and +TRACE+/+TRAP+ when non-zero (0 is their idle default).
+      # The result is both human-readable and re-assemblable.
+      # @param [Integer] value
+      # @return [String?]
+      def self.action_label(value)
+        action = ACTION.invert[value & SECCOMP_RET_ACTION_FULL]
+        return if action.nil?
+
+        data = value & SECCOMP_RET_DATA
+        case action
+        when :ERRNO then "ERRNO(#{data})"
+        when :TRACE, :TRAP then data.zero? ? action.to_s : "#{action}(#{data})"
+        else action.to_s
+        end
+      end
     end
 
     # Define syscall numbers for all architectures.

--- a/lib/seccomp-tools/instruction/ret.rb
+++ b/lib/seccomp-tools/instruction/ret.rb
@@ -37,9 +37,8 @@ module SeccompTools
         _, type = symbolize
         return 'A' if type == :a
 
-        str = ACTION.invert[type & SECCOMP_RET_ACTION_FULL].to_s
-        str += "(#{type & SECCOMP_RET_DATA})" if str == 'ERRNO'
-        str
+        # fall back to the raw value (still re-assemblable) for an action the kernel does not define
+        Const::BPF.action_label(type) || "0x#{type.to_s(16)}"
       end
     end
   end

--- a/spec/const_spec.rb
+++ b/spec/const_spec.rb
@@ -19,3 +19,20 @@ describe SeccompTools::Const::Audit do
     end
   end
 end
+
+describe SeccompTools::Const::BPF do
+  describe '.action_label' do
+    it 'names a return value, showing the data ERRNO/TRACE/TRAP consume' do
+      expect(described_class.action_label(0x7fff0000)).to eq 'ALLOW'
+      expect(described_class.action_label(0x00000000)).to eq 'KILL'
+      expect(described_class.action_label(0x00050005)).to eq 'ERRNO(5)' # data always shown
+      expect(described_class.action_label(0x7ff00007)).to eq 'TRACE(7)'
+      expect(described_class.action_label(0x00030005)).to eq 'TRAP(5)'
+      expect(described_class.action_label(0x7ff00000)).to eq 'TRACE' # idle data 0 omitted
+    end
+
+    it 'is nil when the action bits are not a kernel-defined value' do
+      expect(described_class.action_label(0x12345678)).to be_nil
+    end
+  end
+end

--- a/spec/disasm/disasm_spec.rb
+++ b/spec/disasm/disasm_spec.rb
@@ -526,4 +526,14 @@ describe SeccompTools::Disasm do
     out = described_class.disasm(SeccompTools::Asm.asm(src, arch: :amd64), arch: :amd64, display_bpf: false)
     expect(out).to include('A = fd # write(fd, buf, count)')
   end
+
+  it 'shows TRACE/TRAP data and an unknown action, all re-assemblable' do
+    { 'TRACE(5)' => 'return TRACE(5)', 'TRAP(7)' => 'return TRAP(7)',
+      '0x12345678' => 'return 0x12345678' }.each do |asm, expected|
+      raw = SeccompTools::Asm.asm("return #{asm}", arch: :amd64)
+      out = described_class.disasm(raw, arch: :amd64, display_bpf: false)
+      expect(out).to include(expected)
+      expect(SeccompTools::Asm.asm(out.sub(/\A\d+: /, ''), arch: :amd64)).to eq raw # faithful round-trip
+    end
+  end
 end


### PR DESCRIPTION
Add Const::BPF.action_label(value) and have Instruction::RET use it. The old ret_str duplicated the action decode and was incomplete: it dropped TRACE/TRAP data (so return TRACE(5) disassembled to TRACE and no longer round-tripped) and rendered an unknown action as an empty string. It now shows TRACE(5)/TRAP(7) and falls back to the raw value for an unrecognized action, both re-assemblable. Explain::Verdict adopts the same helper once this lands.