### PR TITLE
Make the symbolic key a string so states hash without collapsing

### DIFF
--- a/lib/seccomp-tools/explain/qword.rb
+++ b/lib/seccomp-tools/explain/qword.rb
@@ -7,9 +7,10 @@ module SeccompTools
     # A 64-bit fact reassembled from 32-bit word checks (see {QwordFusion}); +base+ is the field's
     # byte offset in +seccomp_data+.
     Qword = Struct.new(:base, :op, :val) do
-      # Mirrors {Symbolic::Constraint#key} so fused condition lists can still be compared.
+      # Mirrors {Symbolic::Constraint#key} (a string) so fused condition lists can still be compared;
+      # the +q+ prefix keeps it distinct from any constraint key, which starts with an operand char.
       def key
-        [:qword, base, op, val]
+        "q#{base},#{op},#{val}"
       end
 
       # A {Qword} is a whole-field fact, never a single plain-word one, so it matches neither

--- a/lib/seccomp-tools/symbolic/constraint.rb
+++ b/lib/seccomp-tools/symbolic/constraint.rb
@@ -69,10 +69,11 @@ module SeccompTools
         op == :== && plain_data_fact?(offset)
       end
 
-      # A value that uniquely identifies this constraint, for hashing and equality.
-      # @return [Array]
+      # A string that uniquely identifies this constraint, for both equality and hashing; the
+      # +expr op expr+ counterpart of {Expr#key}, injective for the same reason.
+      # @return [String]
       def key
-        [lhs.key, op, rhs.key]
+        @key ||= "#{lhs.key}#{op}#{rhs.key}"
       end
     end
   end

--- a/lib/seccomp-tools/symbolic/executor.rb
+++ b/lib/seccomp-tools/symbolic/executor.rb
@@ -82,7 +82,7 @@ module SeccompTools
           steps += 1
           pc, st = stack.pop
           next if pc >= @instructions.size
-          next unless visited.add?([pc, st.signature])
+          next unless visited.add?([pc, st.key])
 
           step(pc, st, leaves, stack)
         end

--- a/lib/seccomp-tools/symbolic/expr.rb
+++ b/lib/seccomp-tools/symbolic/expr.rb
@@ -124,16 +124,23 @@ module SeccompTools
         Expr.binop(op, self, operand)
       end
 
-      # A value that uniquely identifies this expression, for hashing and equality (so the executor
-      # can recognise two states as identical). Sub-expressions are reduced to their own keys, so the
-      # result is a plain nested value.
-      # @return [Array]
+      # A string that uniquely identifies this expression, used for both equality and hashing;
+      # memoized, since an {Expr} is immutable. The operator is written as text, not left a {Symbol},
+      # because Ruby's +Symbol#hash+ maps the operators to very few values (+:==+ and +:!=+ hash
+      # alike) — a key carrying them would collapse when hashed and drag the walk's visited +Set+
+      # down to a linear scan; a string hashes over its bytes cleanly. The encoding is injective
+      # (leaves are +i<val>+ / +d<offset>+ / +o+, compounds are parenthesised, and no operator
+      # contains a leaf-start char, a digit, or the +;+ / +,+ that {State} joins with), so it is
+      # safe to compare on.
+      # @return [String]
       def key
-        case kind
-        when :binop then [:binop, op, lhs.key, rhs.key]
-        when :unop then [:unop, op, lhs.key]
-        else [kind, val, offset]
-        end
+        @key ||= case kind
+                 when :binop then "(#{lhs.key}#{op}#{rhs.key})"
+                 when :unop  then "(#{op}#{lhs.key})"
+                 when :imm   then "i#{val}"
+                 when :data  then "d#{offset}"
+                 else 'o'
+                 end
       end
 
       # @param [Expr] other

--- a/lib/seccomp-tools/symbolic/state.rb
+++ b/lib/seccomp-tools/symbolic/state.rb
@@ -48,11 +48,14 @@ module SeccompTools
         State.new(a:, x:, mem:, path:)
       end
 
-      # A value that uniquely identifies this state. The walk uses it to skip a +(line, state)+ pair
-      # it has already visited, which keeps merging control-flow from blowing up.
-      # @return [Array]
-      def signature
-        [a.key, x.key, mem.map(&:key), path.map(&:key)]
+      # A string that identifies this state exactly, joined from each part's {Expr#key} /
+      # {Constraint#key} (the same identity, one level up). The walk uses it to skip a
+      # +(line, state)+ pair it has already visited, which keeps merging control-flow from blowing
+      # up. Both {#==} and {#hash} are decided on it; see {Expr#key} for why the key is a string.
+      # The +;+ / +,+ separators appear in no part's key, so the join stays injective.
+      # @return [String]
+      def key
+        @key ||= "#{a.key};#{x.key};#{mem.map(&:key).join(',')};#{path.map(&:key).join(',')}"
       end
 
       # The constant the data word at byte +offset+ is pinned to on this path (by an +==+ fact), or
@@ -66,13 +69,13 @@ module SeccompTools
       # @param [State] other
       # @return [Boolean]
       def ==(other)
-        other.is_a?(State) && signature == other.signature
+        other.is_a?(State) && key == other.key
       end
       alias eql? ==
 
       # @return [Integer]
       def hash
-        signature.hash
+        key.hash
       end
     end
   end

--- a/spec/explain/qword_spec.rb
+++ b/spec/explain/qword_spec.rb
@@ -21,7 +21,7 @@ describe SeccompTools::Explain::QwordFusion do
   describe SeccompTools::Explain::Qword do
     it 'has a key mirroring Constraint#key so fused lists stay comparable' do
       q = described_class.new(16, :==, 0x100000002)
-      expect(q.key).to eq [:qword, 16, :==, 0x100000002]
+      expect(q.key).to eq 'q16,==,4294967298'
       expect(q.key).not_to eq described_class.new(16, :==, 0x3).key
     end
   end

--- a/spec/symbolic/executor_spec.rb
+++ b/spec/symbolic/executor_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'timeout'
+
 require 'seccomp-tools/bpf'
 require 'seccomp-tools/const'
 require 'seccomp-tools/disasm/disasm'
@@ -145,6 +147,26 @@ describe SeccompTools::Symbolic::Executor do
     stub_const('SeccompTools::Symbolic::Executor::STEP_CAP', 1)
     _, truncated = run([inst(cmd(:ld, mode: :abs), k: 0), inst(cmd(:ret), k: 0)])
     expect(truncated).to be true
+  end
+
+  it 'walks re-merging control flow without the visited set degrading to a linear scan' do
+    # A chain of N diamonds: each loads a distinct data word, forks on `== k`, and rejoins before
+    # the next. Because both branches rejoin, 2^N distinct path conditions reach the final return.
+    # The visited set dedups on the state key, which embeds the path condition; that only keeps the
+    # walk tractable if the state *hashes* well. Its hash used to be that of a nested Array, which
+    # collapses when siblings differ only in a comparison operator (Ruby maps :== and :!= to one
+    # hash), turning every insert into an O(n) scan and this walk into minutes of work.
+    n = 11
+    insts = Array.new(n) do |i|
+      [inst(cmd(:ld, mode: :abs), k: i * 4), # A = data[i*4] (a distinct word)
+       inst(cmd(:jmp, jmp: :jeq, src: :k), jt: 1, jf: 0, k: 0x1000 + i), # A == k -> merge, skipping
+       inst(cmd(:jmp, jmp: :ja), k: 0)] # ...the unconditional rejoin
+    end.flatten << inst(cmd(:ret), k: 0x7fff0000)
+
+    leaves = Timeout.timeout(5) { leaves_of(insts) }
+    # Every word is independent, so all 2^N paths are feasible and reach ALLOW.
+    expect(leaves.size).to be(2**n)
+    expect(rets(leaves).uniq).to eq [0x7fff0000]
   end
 
   context 'feasibility pruning' do

--- a/spec/symbolic/state_spec.rb
+++ b/spec/symbolic/state_spec.rb
@@ -17,7 +17,7 @@ describe SeccompTools::Symbolic::State do
   end
 
   describe 'value equality' do
-    it 'compares by signature, so equal states dedup in a Set' do
+    it 'compares by key, so equal states dedup in a Set' do
       a = described_class.initial.with(a: expr.data(0))
       b = described_class.initial.with(a: expr.data(0))
       expect(a).to eq b
@@ -45,9 +45,9 @@ describe SeccompTools::Symbolic::State do
     expect(st.a.val).to be 0 # original untouched
   end
 
-  it 'has a signature that reflects its contents' do
+  it 'has a key that reflects its contents' do
     st = described_class.initial
-    expect(st.signature).to eq described_class.initial.signature
-    expect(st.with(a: SeccompTools::Symbolic::Expr.imm(5)).signature).not_to eq st.signature
+    expect(st.key).to eq described_class.initial.key
+    expect(st.with(a: SeccompTools::Symbolic::Expr.imm(5)).key).not_to eq st.key
   end
 end


### PR DESCRIPTION
The executor dedups states on (line, key). When key was a nested Array it collapsed in Ruby's Set: :==.hash == :!=.hash, so sibling path conditions (differing only by that operator at each fork) shared a bucket, turning every insert into a linear scan and a re-merging filter's explain/disasm walk into quadratic time (a 37-instruction filter took ~140s).

Have every #key (Expr, Constraint, State, Qword) return a string instead. String#hash is over the bytes, so it doesn't collapse; the encoding is injective (no operator string contains an operand-start char, a digit, or the ; / , separators), so it's still safe to compare on. One identity that is both equality and hash: no separate fingerprint, no bespoke State#hash. ~500x faster on the pathological case.