### PR TITLE
Warn when a dump finds no seccomp filter

### DIFF
--- a/lib/seccomp-tools/cli/dumpable.rb
+++ b/lib/seccomp-tools/cli/dumpable.rb
@@ -14,6 +14,7 @@ module SeccompTools
       #
       # When +pid+ is given the process is traced (requiring +CAP_SYS_ADMIN+); otherwise +command+
       # is executed. On a permission error while tracing a pid, {#dump_permission_error} exits.
+      # Warns when nothing was installed, so a caller that produces no output still tells the user why.
       # @param [String?] command
       #   The command to run, when +pid+ is +nil+.
       # @param [Integer?] pid
@@ -27,11 +28,15 @@ module SeccompTools
       # @yieldparam [Symbol?] arch
       #   The architecture of the traced process, if known.
       # @return [Array]
-      #   One entry per filter: the block's return values.
+      #   One entry per filter: the block's return values. Empty when nothing was installed.
       def dump_seccomp(command:, pid:, limit:, timeout:, &)
-        return dump_seccomp_by_pid(pid, limit, &) if pid
-
-        SeccompTools::Dumper.dump('/bin/sh', '-c', command, limit:, timeout:, &)
+        filters = if pid
+                    dump_seccomp_by_pid(pid, limit, &)
+                  else
+                    SeccompTools::Dumper.dump('/bin/sh', '-c', command, limit:, timeout:, &)
+                  end
+        Logger.warn('No seccomp filter was installed.') if filters.empty?
+        filters
       end
 
       # Whether tracer-based dumping is available on this platform (Linux only). Logs an error when

--- a/lib/seccomp-tools/cli/explain.rb
+++ b/lib/seccomp-tools/cli/explain.rb
@@ -127,11 +127,9 @@ module SeccompTools
       def dump_filters(command:, pid:, source:)
         return [] unless dumping_supported?
 
-        filters = dump_seccomp(command:, pid:, limit: option[:limit], timeout: option[:timeout]) do |bpf, arch|
+        dump_seccomp(command:, pid:, limit: option[:limit], timeout: option[:timeout]) do |bpf, arch|
           [bpf, arch || option[:arch], source]
         end
-        Logger.warn('No seccomp filter was installed.') if filters.empty?
-        filters
       end
 
       # Is +file+ an ELF executable to run, rather than a raw BPF blob or stdin to read?

--- a/spec/cli/dump_spec.rb
+++ b/spec/cli/dump_spec.rb
@@ -65,7 +65,8 @@ EOS
 
   it 'timeout' do
     start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    expect { described_class.new(['-c', 'sleep 1d', '-t', '1']).handle }.not_to output.to_stdout
+    expect { described_class.new(['-c', 'sleep 1d', '-t', '1']).handle }
+      .to output("[WARN] No seccomp filter was installed.\n").to_stdout
     expect(Process.clock_gettime(Process::CLOCK_MONOTONIC) - start).to be < 2
   end
 
@@ -88,7 +89,7 @@ EOS
       command = nil
       allow(SeccompTools::Dumper).to receive(:dump) do |*args, **|
         command = args[2]
-        []
+        ['filter'] # non-empty, so the "no filter" warning stays out of these argument checks
       end
       -> { command }
     end
@@ -107,9 +108,15 @@ EOS
     end
 
     it 'warns about positional arguments left after --pid' do
-      allow(SeccompTools::Dumper).to receive(:dump_by_pid).and_return([])
+      allow(SeccompTools::Dumper).to receive(:dump_by_pid).and_return(['filter'])
       expect { described_class.new(['-p', '123', './extra']).handle }
         .to output("[WARN] ignoring unused argument: ./extra\n").to_stdout
     end
+  end
+
+  it 'warns when the target installs no seccomp filter' do
+    expect(SeccompTools::Dumper).to receive(:dump).with('/bin/sh', '-c', './x', anything) { [] }
+    expect { described_class.new(['-c', './x']).handle }
+      .to output("[WARN] No seccomp filter was installed.\n").to_stdout
   end
 end


### PR DESCRIPTION
`dump` was silent (no output, exit 0) when the target installed no filter, indistinguishable from a swallowed error. `explain` already warned; hoist that check into the shared Dumpable#dump_seccomp so both commands report it.