### PR TITLE
Extract CLI::FilterInput for reuse

### DIFF
--- a/lib/seccomp-tools/cli/dump.rb
+++ b/lib/seccomp-tools/cli/dump.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'seccomp-tools/cli/base'
-require 'seccomp-tools/cli/dumpable'
+require 'seccomp-tools/cli/filter_input'
 require 'seccomp-tools/disasm/disasm'
 require 'seccomp-tools/dumper'
 
@@ -9,7 +9,7 @@ module SeccompTools
   module CLI
     # Handle 'dump' command.
     class Dump < Base
-      include Dumpable
+      include FilterInput
 
       # Summary of this command.
       SUMMARY = 'Automatically dump seccomp bpf from execution file(s).'
@@ -83,18 +83,26 @@ module SeccompTools
         return unless dumping_supported?
         return unless super
 
-        block = lambda do |bpf, arch|
-          case option[:format]
-          when :inspect then output { "\"#{bpf.bytes.map { |b| format('\\x%02X', b) }.join}\"\n" }
-          when :raw then output { bpf }
-          when :disasm then output { SeccompTools::Disasm.disasm(bpf, arch:) }
-          end
+        collect_filters.each { |bpf, arch| emit(bpf, arch) }
+      end
+
+      private
+
+      # A positional argument is always an executable to trace, never a raw BPF blob to read: that is
+      # +disasm+'s job, and a non-ELF executable (a shell script wrapping the target) must still run.
+      # @return [Boolean]
+      def accepts_raw_bpf?
+        false
+      end
+
+      # Writes one dumped filter in the requested format.
+      # @return [void]
+      def emit(bpf, arch)
+        case option[:format]
+        when :inspect then output { "\"#{bpf.bytes.map { |b| format('\\x%02X', b) }.join}\"\n" }
+        when :raw then output { bpf }
+        when :disasm then output { SeccompTools::Disasm.disasm(bpf, arch:) }
         end
-        # -c/--sh-exec takes precedence; a positional exec is used only when -c is absent.
-        option[:command] ||= argv.shift unless option[:pid]
-        warn_ignored_arguments
-        dump_seccomp(command: option[:command], pid: option[:pid], limit: option[:limit], timeout: option[:timeout],
-                     &block)
       end
     end
   end

--- a/lib/seccomp-tools/cli/explain.rb
+++ b/lib/seccomp-tools/cli/explain.rb
@@ -1,18 +1,16 @@
 # frozen_string_literal: true
 
 require 'seccomp-tools/cli/base'
-require 'seccomp-tools/cli/dumpable'
+require 'seccomp-tools/cli/filter_input'
 require 'seccomp-tools/disasm/disasm'
-require 'seccomp-tools/dumper'
 require 'seccomp-tools/explain'
 require 'seccomp-tools/logger'
-require 'seccomp-tools/util'
 
 module SeccompTools
   module CLI
     # Handle 'explain' command.
     class Explain < Base
-      include Dumpable
+      include FilterInput
 
       # Summary of this command.
       SUMMARY = 'Summarize a seccomp filter as a per-action policy.'
@@ -75,77 +73,6 @@ module SeccompTools
           insts = SeccompTools::Disasm.to_bpf(raw, arch).map(&:inst)
           output { SeccompTools::Explain.new(insts, arch:, source: label).summarize.to_s }
         end
-      end
-
-      private
-
-      # Resolves the input into an array of +[raw_bpf, arch, source]+ tuples, empty when there is
-      # nothing to explain (help shown, or an error was logged).
-      #
-      # The input is one of three kinds:
-      # * a running process, when +--pid+ is given;
-      # * a raw BPF file (or stdin), when the positional argument is not an executable;
-      # * a command to run and trace - either +-c+, or a positional executable.
-      # @return [Array<Array(String, Symbol, String?)>]
-      def collect_filters
-        # -c/--sh-exec and --pid take precedence over a positional BPF file or executable.
-        option[:ifile] = argv.shift unless option[:command] || option[:pid]
-        warn_ignored_arguments
-
-        return dump_filters(command: nil, pid: option[:pid], source: "pid #{option[:pid]}") if option[:pid]
-
-        command = option[:command] || option[:ifile]
-        if command.nil? # nothing to explain
-          CLI.show(parser.help)
-          return []
-        end
-        return read_raw_bpf if raw_bpf_file?
-
-        dump_filters(command:, pid: nil, source: command)
-      end
-
-      # Reads the positional file (or stdin) as a raw BPF blob, logging an error instead of
-      # crashing when it cannot be read.
-      # @return [Array<Array(String, Symbol, String?)>]
-      def read_raw_bpf
-        [[input, option[:arch], source_name(option[:ifile])]]
-      rescue SystemCallError => e
-        Logger.error(e.message)
-        []
-      end
-
-      # Should the input be read directly as a raw BPF blob, rather than run as a command? True when
-      # no +-c+ was given and the positional argument is not an executable (a plain file or stdin).
-      # @return [Boolean]
-      def raw_bpf_file?
-        !option[:command] && !executable?(option[:ifile])
-      end
-
-      # Dumps filters from a command or pid and labels each with +source+.
-      # @return [Array<Array(String, Symbol, String?)>]
-      #   The filter tuples, empty when dumping is unsupported or nothing was installed.
-      def dump_filters(command:, pid:, source:)
-        return [] unless dumping_supported?
-
-        dump_seccomp(command:, pid:, limit: option[:limit], timeout: option[:timeout]) do |bpf, arch|
-          [bpf, arch || option[:arch], source]
-        end
-      end
-
-      # Is +file+ an ELF executable to run, rather than a raw BPF blob or stdin to read?
-      # @param [String?] file
-      #   The path to check. +nil+ (no argument) and +-+ (stdin) are not executables.
-      # @return [Boolean]
-      def executable?(file)
-        file && file != '-' && Util.elf?(file)
-      end
-
-      # The label shown in the policy header for +file+; +<STDIN>+ when reading from stdin.
-      # @param [String] file
-      #   The input path, or +-+ for stdin.
-      # @return [String]
-      def source_name(file)
-        file == '-' ? '<STDIN>' : file
       end
     end
   end

--- a/lib/seccomp-tools/cli/filter_input.rb
+++ b/lib/seccomp-tools/cli/filter_input.rb
@@ -52,10 +52,20 @@ module SeccompTools
       end
 
       # Should the input be read directly as a raw BPF blob, rather than run as a command? True when
-      # no +-c+ was given and the positional argument is not an executable (a plain file or stdin).
+      # the command accepts blobs at all, no +-c+ was given, and the positional argument is not an
+      # executable (a plain file or stdin).
       # @return [Boolean]
       def raw_bpf_file?
-        !option[:command] && !executable?(option[:ifile])
+        accepts_raw_bpf? && !option[:command] && !executable?(option[:ifile])
+      end
+
+      # Does a positional argument that is not an ELF mean "read this filter"? True for the commands
+      # that analyze a filter ({Explain}, {Audit}); {Dump} overrides it to +false+, because its
+      # positional is always something to execute - a shell script is not an ELF but must still be
+      # run, not parsed as BPF.
+      # @return [Boolean]
+      def accepts_raw_bpf?
+        true
       end
 
       # Dumps filters from a command or pid and labels each with +source+.

--- a/lib/seccomp-tools/cli/filter_input.rb
+++ b/lib/seccomp-tools/cli/filter_input.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/cli/dumpable'
+require 'seccomp-tools/logger'
+require 'seccomp-tools/util'
+
+module SeccompTools
+  module CLI
+    # Shared input handling for the commands that take a seccomp filter from a BPF file, stdin, an
+    # executable, or a running process ({Explain} and {Audit}): it resolves the positional argument
+    # and options into +[raw_bpf, arch, source]+ tuples, dumping via ptrace ({Dumpable}) when the
+    # input is a command or +--pid+. The including command must provide +option+, +argv+, +parser+,
+    # +input+ and +warn_ignored_arguments+ (all from {Base}).
+    module FilterInput
+      include Dumpable
+
+      private
+
+      # Resolves the input into an array of +[raw_bpf, arch, source]+ tuples, empty when there is
+      # nothing to process (help shown, or an error was logged).
+      #
+      # The input is one of three kinds:
+      # * a running process, when +--pid+ is given;
+      # * a raw BPF file (or stdin), when the positional argument is not an executable;
+      # * a command to run and trace - either +-c+, or a positional executable.
+      # @return [Array<Array(String, Symbol, String?)>]
+      def collect_filters
+        # -c/--sh-exec and --pid take precedence over a positional BPF file or executable.
+        option[:ifile] = argv.shift unless option[:command] || option[:pid]
+        warn_ignored_arguments
+
+        return dump_filters(command: nil, pid: option[:pid], source: "pid #{option[:pid]}") if option[:pid]
+
+        command = option[:command] || option[:ifile]
+        if command.nil? # nothing to process
+          CLI.show(parser.help)
+          return []
+        end
+        return read_raw_bpf if raw_bpf_file?
+
+        dump_filters(command:, pid: nil, source: command)
+      end
+
+      # Reads the positional file (or stdin) as a raw BPF blob, logging an error instead of
+      # crashing when it cannot be read.
+      # @return [Array<Array(String, Symbol, String?)>]
+      def read_raw_bpf
+        [[input, option[:arch], source_name(option[:ifile])]]
+      rescue SystemCallError => e
+        Logger.error(e.message)
+        []
+      end
+
+      # Should the input be read directly as a raw BPF blob, rather than run as a command? True when
+      # no +-c+ was given and the positional argument is not an executable (a plain file or stdin).
+      # @return [Boolean]
+      def raw_bpf_file?
+        !option[:command] && !executable?(option[:ifile])
+      end
+
+      # Dumps filters from a command or pid and labels each with +source+.
+      # @return [Array<Array(String, Symbol, String?)>]
+      #   The filter tuples, empty when dumping is unsupported or nothing was installed.
+      def dump_filters(command:, pid:, source:)
+        return [] unless dumping_supported?
+
+        dump_seccomp(command:, pid:, limit: option[:limit], timeout: option[:timeout]) do |bpf, arch|
+          [bpf, arch || option[:arch], source]
+        end
+      end
+
+      # Is +file+ an ELF executable to run, rather than a raw BPF blob or stdin to read?
+      # @param [String?] file
+      #   The path to check. +nil+ (no argument) and +-+ (stdin) are not executables.
+      # @return [Boolean]
+      def executable?(file)
+        file && file != '-' && Util.elf?(file)
+      end
+
+      # The label shown in the header for +file+; +<STDIN>+ when reading from stdin.
+      # @param [String] file
+      #   The input path, or +-+ for stdin.
+      # @return [String]
+      def source_name(file)
+        file == '-' ? '<STDIN>' : file
+      end
+    end
+  end
+end

--- a/spec/cli/dump_spec.rb
+++ b/spec/cli/dump_spec.rb
@@ -85,32 +85,35 @@ EOS
   end
 
   context 'argument handling' do
+    # One `return ALLOW`, so a stubbed dump yields a filter the command can really format.
+    def allow_filter = "\x06\x00\x00\x00\x00\x00\xff\x7f"
+
     def stub_dump_capturing_command
       command = nil
-      allow(SeccompTools::Dumper).to receive(:dump) do |*args, **|
+      allow(SeccompTools::Dumper).to receive(:dump) do |*args, **, &blk|
         command = args[2]
-        ['filter'] # non-empty, so the "no filter" warning stays out of these argument checks
+        [blk.call(allow_filter, :amd64)]
       end
       -> { command }
     end
 
     it 'prefers -c over a positional exec and warns about the unused one' do
       command = stub_dump_capturing_command
-      expect { described_class.new(['-c', 'true', './extra']).handle }
-        .to output("[WARN] ignoring unused argument: ./extra\n").to_stdout
+      expect { described_class.new(['-c', 'true', './extra', '-f', 'raw']).handle }
+        .to output("[WARN] ignoring unused argument: ./extra\n#{allow_filter}").to_stdout
       expect(command.call).to eq 'true'
     end
 
     it 'uses a lone positional exec without warning' do
       command = stub_dump_capturing_command
-      expect { described_class.new(['./bin']).handle }.not_to output.to_stdout
+      expect { described_class.new(['./bin', '-f', 'raw']).handle }.to output(allow_filter).to_stdout
       expect(command.call).to eq './bin'
     end
 
     it 'warns about positional arguments left after --pid' do
-      allow(SeccompTools::Dumper).to receive(:dump_by_pid).and_return(['filter'])
-      expect { described_class.new(['-p', '123', './extra']).handle }
-        .to output("[WARN] ignoring unused argument: ./extra\n").to_stdout
+      allow(SeccompTools::Dumper).to receive(:dump_by_pid) { |*, &blk| [blk.call(allow_filter, :amd64)] }
+      expect { described_class.new(['-p', '123', './extra', '-f', 'raw']).handle }
+        .to output("[WARN] ignoring unused argument: ./extra\n#{allow_filter}").to_stdout
     end
   end
 


### PR DESCRIPTION
Move explain's filter-input plumbing (collect_filters, read_raw_bpf, raw_bpf_file?, dump_filters, executable?, source_name) into a FilterInput mixin so the upcoming audit command reads the same inputs (BPF file, stdin, executable, --pid) without duplication.