### PR TITLE
Detect the architecture when dumping by pid

### DIFF
--- a/lib/seccomp-tools/dumper.rb
+++ b/lib/seccomp-tools/dumper.rb
@@ -6,6 +6,7 @@ require 'timeout'
 require 'seccomp-tools/logger'
 require 'seccomp-tools/ptrace' if OS.linux?
 require 'seccomp-tools/syscall'
+require 'seccomp-tools/util'
 
 module SeccompTools
   # Dump seccomp-bpf using ptrace of binary.
@@ -33,7 +34,8 @@ module SeccompTools
     # @yieldparam [String] bpf
     #   Seccomp bpf in raw bytes.
     # @yieldparam [Symbol?] arch
-    #   Architecture of the target process, always +nil+ right now.
+    #   Architecture of the target process, +nil+ when it cannot be determined.
+    #   See {SeccompTools::Util.process_arch}.
     # @return [Array<Object>, Array<String>]
     #   One entry per dumped filter: the block's return values when a block is given, otherwise the
     #   raw bytes. Empty on a non-Linux platform, where dumping is unsupported.
@@ -177,8 +179,9 @@ module SeccompTools
     #   Number of filters to dump. Negative number for unlimited.
     # @yieldparam [String] bpf
     #   Seccomp bpf in raw bytes.
-    # @yieldparam [Symbol] arch
-    #   Architecture of the target process (always nil right now).
+    # @yieldparam [Symbol?] arch
+    #   Architecture of the target process, +nil+ when it cannot be determined.
+    #   See {SeccompTools::Util.process_arch}.
     # @return [Array<Object>, Array<String>]
     #   Returns what the block returned. If a block is not given, an array of raw bytes will be returned.
     # @raise [Errno::ESRCH]
@@ -202,6 +205,7 @@ module SeccompTools
       return [] unless SUPPORTED
 
       collect = []
+      arch = Util.process_arch(pid)
       Ptrace.attach_and_wait(pid)
       begin
         i = 0
@@ -211,7 +215,7 @@ module SeccompTools
           rescue Errno::ENOENT, Errno::EINVAL
             break
           end
-          collect << (block.nil? ? bpf : yield(bpf, nil))
+          collect << (block.nil? ? bpf : yield(bpf, arch))
           i += 1
         end
       ensure

--- a/lib/seccomp-tools/syscall.rb
+++ b/lib/seccomp-tools/syscall.rb
@@ -4,6 +4,7 @@
 require 'os'
 
 require 'seccomp-tools/const'
+require 'seccomp-tools/util'
 require 'seccomp-tools/ptrace' if OS.linux?
 
 module SeccompTools
@@ -119,21 +120,11 @@ module SeccompTools
       Array.new(len) { |i| Ptrace.peekdata(pid, filter + (i * 8), 0) }.pack('Q*')
     end
 
-    # Architecture of this syscall, determined by the ELF machine type of +/proc/pid/exe+.
+    # Architecture of this syscall, i.e. of the traced process.
     # @return [Symbol?]
-    #   One of +:i386+, +:amd64+, +:aarch64+, +:riscv64+, +:s390x+, or +nil+ if the machine type is
-    #   unrecognized.
+    #   See {SeccompTools::Util.process_arch}.
     def arch
-      @arch ||= File.open("/proc/#{pid}/exe", 'rb') do |f|
-        f.pos = 18
-        {
-          "\x03\x00" => :i386,
-          "\x3e\x00" => :amd64,
-          "\xb7\x00" => :aarch64,
-          "\xf3\x00" => :riscv64,
-          "\x00\x16" => :s390x
-        }[f.read(2)]
-      end
+      @arch ||= Util.process_arch(pid)
     end
 
     private

--- a/lib/seccomp-tools/util.rb
+++ b/lib/seccomp-tools/util.rb
@@ -30,6 +30,36 @@ module SeccompTools
       end
     end
 
+    # ELF +e_machine+ values (the halfword at offset 18) of the architectures seccomp-tools supports,
+    # as they are laid out in the file - so the big-endian s390x reads the other way around. The keys
+    # are binary strings (+.b+) to match what is read off the file: this source is UTF-8, where a
+    # literal such as +"\xb7\x00"+ would never compare equal to those bytes.
+    ELF_MACHINE = {
+      "\x03\x00".b => :i386,
+      "\x3e\x00".b => :amd64,
+      "\xb7\x00".b => :aarch64,
+      "\xf3\x00".b => :riscv64,
+      "\x00\x16".b => :s390x
+    }.freeze
+
+    # The architecture a running process was built for, read from the ELF header of its executable.
+    #
+    # Filters dumped from another process are numbered for *its* architecture, so this is what makes
+    # the syscall names right when it differs from the host.
+    # @param [Integer] pid
+    #   Process identifier.
+    # @return [Symbol?]
+    #   One of {supported_archs}, or +nil+ when the executable cannot be read (no +/proc+, the
+    #   process is gone, permission denied) or its machine type is not one we know.
+    def process_arch(pid)
+      File.open("/proc/#{pid}/exe", 'rb') do |f|
+        f.pos = 18
+        ELF_MACHINE[f.read(2)]
+      end
+    rescue SystemCallError
+      nil
+    end
+
     # Enable colorize.
     #
     # Colors are still only emitted when the output is a tty, see {colorize_enabled?}.

--- a/spec/dumper_spec.rb
+++ b/spec/dumper_spec.rb
@@ -108,6 +108,18 @@ describe SeccompTools::Dumper do
   end
 
   describe 'by pid' do
+    it 'yields the architecture of the target process' do
+      skip 'ptrace is Linux-only' unless described_class::SUPPORTED
+
+      # Tracing our own pid, so /proc/self/exe is ruby: the filters are read through a stubbed
+      # ptrace, but the architecture is really detected - it used to always be nil here.
+      allow(SeccompTools::Ptrace).to receive(:attach_and_wait)
+      allow(SeccompTools::Ptrace).to receive(:detach)
+      allow(SeccompTools::Ptrace).to receive(:seccomp_get_filter).and_return("\x06\x00\x00\x00\x00\x00\xff\x7f")
+      arches = described_class.dump_by_pid(Process.pid, 1) { |_bpf, arch| arch }
+      expect(arches).to eq [SeccompTools::Util.system_arch]
+    end
+
     context 'two filters' do
       let(:bin) { bin_of('two_filters') }
 

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -41,6 +41,30 @@ describe SeccompTools::Util do
     expect(described_class.elf?('/no/such/file')).to be false
   end
 
+  describe 'process_arch' do
+    it 'reads the architecture of a running process' do
+      # our own process: whatever ruby was built for, i.e. the host architecture
+      expect(described_class.process_arch(Process.pid)).to be described_class.system_arch
+    end
+
+    it 'is nil when the executable cannot be read' do
+      expect(described_class.process_arch(0x7fffffff)).to be_nil
+    end
+
+    it 'matches the machine bytes as read off a file, for every supported architecture' do
+      # Guards the encoding trap: a literal like "\xb7\x00" in a UTF-8 source never compares equal
+      # to the same bytes read in binary mode, which would silently stop detecting those arches.
+      described_class::ELF_MACHINE.each do |bytes, arch|
+        Tempfile.create(['seccomp-tools-', '']) do |f|
+          f.binmode
+          f.write(("\x00" * 18) + bytes) # e_machine is the halfword at offset 18
+          f.close
+          expect(described_class::ELF_MACHINE[File.binread(f.path, 2, 18)]).to be arch
+        end
+      end
+    end
+  end
+
   it 'colorize' do
     allow(described_class).to receive(:colorize_enabled?).and_return(true)
     expect(described_class.colorize('meow', t: :syscall)).to eq "\e[38;5;120mmeow\e[0m"


### PR DESCRIPTION
dump_by_pid always yielded a nil architecture, so `dump -p` and `explain -p` fell back to the host and mislabelled the syscalls of a process built for another architecture - and `dump` has no --arch to correct it. Read the architecture from /proc/PID/exe, the same way tracing an executable already does, and share that lookup as Util.process_arch.