### PR TITLE
Give warn and info a color

### DIFF
--- a/lib/seccomp-tools/util.rb
+++ b/lib/seccomp-tools/util.rb
@@ -83,14 +83,18 @@ module SeccompTools
 
     # color code of light yellow
     LIGHT_YELLOW = "\e[38;5;230m"
-    # Color codes for pretty print.
+    # Color codes for pretty print. +error+, +warn+ and +info+ are severities rather than parts of a
+    # filter, shading from alarming to quiet; {SeccompTools::Logger} colors its own levels by the
+    # same names.
     COLOR_CODE = {
       esc_m: "\e[0m",
       syscall: "\e[38;5;120m", # light green
       arch: LIGHT_YELLOW,
       args: LIGHT_YELLOW,
       gray: "\e[2m",
-      error: "\e[38;5;196m" # heavy red
+      error: "\e[38;5;196m", # heavy red
+      warn: LIGHT_YELLOW,
+      info: "\e[38;5;110m" # light blue
     }.freeze
     # Wrap contents with terminal color codes.
     #

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -65,6 +65,14 @@ describe SeccompTools::Util do
     end
   end
 
+  it 'has a color for every severity, including the ones Logger names its levels after' do
+    allow(described_class).to receive(:colorize_enabled?).and_return(true)
+    # Logger colorizes by its downcased level, so a missing entry silently leaves the tag unpainted.
+    %i[error warn info].each do |severity|
+      expect(described_class.colorize(severity.to_s, t: severity)).to start_with("\e[38;5;")
+    end
+  end
+
   it 'colorize' do
     allow(described_class).to receive(:colorize_enabled?).and_return(true)
     expect(described_class.colorize('meow', t: :syscall)).to eq "\e[38;5;120mmeow\e[0m"


### PR DESCRIPTION
Logger colorizes a message by its downcased level, but only error had an entry, so [WARN] came out unpainted. Add warn and info, shading from alarming to quiet alongside error.