### PR TITLE
Rename ArchScope to Analysis

### DIFF
--- a/lib/seccomp-tools/explain/analysis.rb
+++ b/lib/seccomp-tools/explain/analysis.rb
@@ -6,18 +6,18 @@ require 'seccomp-tools/explain/verdict'
 
 module SeccompTools
   class Explain
-    # A filter's leaves split by architecture. {Summary} (to render a per-arch policy) and {Audit}
-    # (to assess each arch's reachable syscalls) reason per architecture the same way, so the
-    # arch-scoping - and the per-leaf {PathFacts} cache it needs - lives here, single-sourced.
-    class ArchScope
+    # What a walk of one filter amounts to: the reachable returns, each one's facts read once, and
+    # the split into the architectures the filter distinguishes.
+    #
+    # Everything that reads a walk needs the same groundwork - {Summary} to render a per-architecture
+    # policy, {Audit} to assess each architecture's reachable syscalls - so it is derived here once
+    # rather than in each of them.
+    class Analysis
       # @param [Array<Symbolic::Executor::Leaf>] leaves
       def initialize(leaves)
         @leaves = leaves
         @facts = Hash.new { |h, leaf| h[leaf] = PathFacts.new(leaf.path) }
       end
-
-      # @return [Array<Symbolic::Executor::Leaf>] All leaves of the filter.
-      attr_reader :leaves
 
       # The {PathFacts} of +leaf+, computed once and shared across all consumers.
       # @param [Symbolic::Executor::Leaf] leaf

--- a/lib/seccomp-tools/explain/summary.rb
+++ b/lib/seccomp-tools/explain/summary.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'seccomp-tools/const'
-require 'seccomp-tools/explain/arch_scope'
+require 'seccomp-tools/explain/analysis'
 require 'seccomp-tools/explain/qword'
 require 'seccomp-tools/explain/renderer'
 require 'seccomp-tools/explain/verdict'
@@ -37,7 +37,7 @@ module SeccompTools
         @truncated = truncated
         @fusion = QwordFusion.new(arch)
         @renderer = Renderer.new(@fusion)
-        @scope = ArchScope.new(leaves)
+        @analysis = Analysis.new(leaves)
       end
 
       # Renders the policy.
@@ -46,7 +46,7 @@ module SeccompTools
         out = +''
         out << "Seccomp policy for #{@source}\n" if @source
         out << "WARNING: analysis truncated (filter too large); results may be incomplete.\n" if @truncated
-        @scope.sections(@arch).each do |_arch_val, arch_sym, title, leaves|
+        @analysis.sections(@arch).each do |_arch_val, arch_sym, title, leaves|
           out << "\n" << render_section(title, section_buckets(arch_sym, leaves))
         end
         out << render_other_arches
@@ -55,19 +55,19 @@ module SeccompTools
 
       private
 
-      # The {PathFacts} of +leaf+, computed once (shared with {ArchScope}).
+      # The {PathFacts} of +leaf+, computed once (shared with {Analysis}).
       def facts(leaf)
-        @scope.facts(leaf)
+        @analysis.facts(leaf)
       end
 
       # Renders what happens on the architectures the filter does not explicitly check for. Usually
       # those paths just fall to one action and a one-liner suffices; when they carry rules of their
       # own, a full section is rendered so the rules are not silently dropped.
       def render_other_arches
-        return '' if @scope.arch_values.empty?
+        return '' if @analysis.arch_values.empty?
 
-        leaves = @scope.other_leaves
-        default = @scope.default_label(leaves)
+        leaves = @analysis.other_leaves
+        default = @analysis.default_label(leaves)
         return '' unless default
 
         buckets = rule_buckets(nil, leaves, default)
@@ -80,7 +80,7 @@ module SeccompTools
       # The action buckets of one section: its non-default rules plus the default rule. +arch_sym+
       # names syscalls/arguments; +nil+ (architecture unknown) leaves them numeric.
       def section_buckets(arch_sym, leaves)
-        default = @scope.default_label(leaves)
+        default = @analysis.default_label(leaves)
         buckets = rule_buckets(arch_sym, leaves, default)
         add_default(buckets, default)
         buckets


### PR DESCRIPTION
The class holds what a walk of one filter amounts to - its leaves, each one's facts read once, and the split by architecture. Only half of that is about architectures, so name the thing rather than one of its jobs. Drop the leaves reader, which nothing used.