### PR TITLE
Add the audit engine: scan a filter for weaknesses

### DIFF
--- a/lib/seccomp-tools/audit.rb
+++ b/lib/seccomp-tools/audit.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/audit/checks'
+require 'seccomp-tools/audit/policy'
+require 'seccomp-tools/audit/report'
+require 'seccomp-tools/explain/analysis'
+require 'seccomp-tools/symbolic/executor'
+
+module SeccompTools
+  # Assesses a seccomp filter for weaknesses / escape routes and reports them as a {Audit::Report}.
+  #
+  # It runs the generic {Symbolic::Executor} over the filter (the same walk {Explain} uses), splits
+  # the leaves per architecture with {Explain::Analysis}, and runs each {Checks} rule against the
+  # per-arch {Policy}. Every supported architecture is assessed; architecture-specific quirks (e.g.
+  # amd64's x32 ABI) are registered per arch in {Checks}, never special-cased inline.
+  #
+  # @example
+  #   insts = SeccompTools::Disasm.to_bpf(raw, :amd64).map(&:inst)
+  #   puts SeccompTools::Audit.new(insts, arch: :amd64, source: 'a.out').audit
+  class Audit
+    # @param [Array<Instruction::Base>] instructions
+    #   The filter, as +SeccompTools::Disasm.to_bpf(raw, arch).map(&:inst)+.
+    # @param [Symbol] arch
+    #   The architecture the filter is written for, used when it does not itself branch on +arch+.
+    # @param [String?] source
+    #   A label for the filter (e.g. a filename) shown in the report.
+    def initialize(instructions, arch:, source: nil)
+      @instructions = instructions
+      @arch = arch
+      @source = source
+    end
+
+    # Walks the filter, runs every check, and returns the {Report}.
+    # @return [Report]
+    def audit
+      leaves, truncated = Symbolic::Executor.new(@instructions).run
+      analysis = Explain::Analysis.new(leaves)
+      policies = analysis.sections(@arch).map { |section| Policy.new(analysis, section) }
+
+      findings = Checks::FILTER.flat_map { |check| check.call(analysis) }
+      policies.each do |policy|
+        Checks.section_checks(policy.arch_sym).each { |check| findings.concat(check.call(policy)) }
+      end
+
+      Report.new(source: @source, arches: policies.map(&:arch_name), findings:, truncated:)
+    end
+  end
+end

--- a/lib/seccomp-tools/audit/catalog.rb
+++ b/lib/seccomp-tools/audit/catalog.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module SeccompTools
+  class Audit
+    # The seccomp-domain knowledge the checks classify against: which syscalls are dangerous, which
+    # are equivalents of each other, and which form a file read/write chain. Entries are by syscall
+    # *name*; each check resolves them against the target architecture's own syscall table (a name a
+    # given arch lacks is simply skipped), and the +*_BY_ARCH+ maps add arch-specific knowledge on a
+    # clean extension point - no arch is hardcoded in the checks themselves.
+    module Catalog
+      # Dangerous-if-reachable syscalls => +{severity:, why:}+. Applied on every architecture. Kept to
+      # a low-noise, high-signal set: syscalls a real sandbox almost never wants. Ubiquitous-but-risky
+      # ones (+mmap+/+mprotect+ RWX, decided by the +prot+ argument) are intentionally out of v1 -
+      # flagging them needs argument-flag analysis, else every normal allowlist trips them.
+      DANGEROUS = {
+        execve: { severity: :high, why: 'arbitrary program execution' },
+        execveat: { severity: :high, why: 'arbitrary program execution' },
+        ptrace: { severity: :high, why: 'inspect/inject into other processes' },
+        process_vm_readv: { severity: :high, why: "read another process's memory" },
+        process_vm_writev: { severity: :high, why: "write another process's memory" },
+        socket: { severity: :medium, why: 'network access (exfiltration)' },
+        connect: { severity: :medium, why: 'network access (exfiltration)' }
+      }.freeze
+
+      # Per-arch additions to {DANGEROUS} (e.g. i386 multiplexes the socket API through +socketcall+).
+      DANGEROUS_BY_ARCH = {
+        i386: { socketcall: { severity: :medium, why: 'multiplexed socket API (exfiltration)' } }
+      }.freeze
+
+      # Equivalent-syscall groups: denying one member while another is allowed is a bypass gap.
+      ALT_GROUPS = {
+        exec: %i[execve execveat],
+        open: %i[open openat openat2],
+        read: %i[read readv pread64 preadv preadv2],
+        write: %i[write writev pwrite64 pwritev sendfile],
+        fork: %i[fork vfork clone clone3]
+      }.freeze
+
+      # Per-arch additions to {ALT_GROUPS}.
+      ALT_GROUPS_BY_ARCH = {}.freeze
+
+      # The open/read/write families whose joint availability is a file read/exfil chain.
+      ORW = {
+        open: %i[open openat openat2],
+        read: %i[read readv pread64 preadv preadv2],
+        write: %i[write writev pwrite64 pwritev sendfile]
+      }.freeze
+
+      module_function
+
+      # {DANGEROUS} plus any per-arch additions for +arch_sym+.
+      # @param [Symbol?] arch_sym
+      # @return [Hash{Symbol=>Hash}]
+      def dangerous(arch_sym)
+        DANGEROUS.merge(DANGEROUS_BY_ARCH.fetch(arch_sym, {}))
+      end
+
+      # {ALT_GROUPS} plus any per-arch additions for +arch_sym+.
+      # @param [Symbol?] arch_sym
+      # @return [Hash{Symbol=>Array<Symbol>}]
+      def alt_groups(arch_sym)
+        ALT_GROUPS.merge(ALT_GROUPS_BY_ARCH.fetch(arch_sym, {}))
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/audit/checks.rb
+++ b/lib/seccomp-tools/audit/checks.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/audit/checks/arch_unchecked'
+require 'seccomp-tools/audit/checks/dangerous_allow'
+require 'seccomp-tools/audit/checks/orw_chain'
+require 'seccomp-tools/audit/checks/permissive_default'
+require 'seccomp-tools/audit/checks/syscall_alt_gap'
+require 'seccomp-tools/audit/checks/x32_guard'
+
+module SeccompTools
+  class Audit
+    # The registries the {Audit} engine runs. A check is anything answering +call+ and returning
+    # {Finding}s; which registry it is listed in decides both how often it runs and what it is
+    # handed, so adding one is a single entry here rather than a change to the engine.
+    #
+    # * {FILTER} - asked once about the whole filter, and handed the {Explain::Analysis}. For
+    #   questions no single architecture can answer, such as whether the filter checks the
+    #   architecture at all.
+    # * {SECTION} / {SECTION_BY_ARCH} - asked once per architecture, and handed that architecture's
+    #   {Policy}. {SECTION_BY_ARCH} keeps a quirk confined to the architecture that has it, so it is
+    #   a one-line entry rather than a branch inside a check.
+    module Checks
+      # Whole-filter checks; each takes the {Explain::Analysis}.
+      FILTER = [ArchUnchecked].freeze
+
+      # Per-architecture checks that apply everywhere; each takes a {Policy}.
+      SECTION = [PermissiveDefault, SyscallAltGap, OrwChain, DangerousAllow].freeze
+
+      # Per-architecture checks that apply only to the keyed architecture (amd64's x32 is the exemplar).
+      SECTION_BY_ARCH = { amd64: [X32Guard] }.freeze
+
+      module_function
+
+      # The per-architecture checks to run for +arch_sym+: the common ones plus any it alone has.
+      # @param [Symbol?] arch_sym
+      # @return [Array]
+      def section_checks(arch_sym)
+        SECTION + SECTION_BY_ARCH.fetch(arch_sym, [])
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/audit/checks/arch_unchecked.rb
+++ b/lib/seccomp-tools/audit/checks/arch_unchecked.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/audit/finding'
+require 'seccomp-tools/explain/verdict'
+
+module SeccompTools
+  class Audit
+    module Checks
+      # The filter does not validate the architecture, or lets an unlisted one reach +ALLOW+. Syscall
+      # numbers are ABI-relative, so number-only rules are dodged by invoking under another ABI.
+      module ArchUnchecked
+        module_function
+
+        # @param [Explain::Analysis] analysis
+        # @return [Array<Audit::Finding>]
+        def call(analysis)
+          if analysis.arch_values.empty?
+            [finding('Architecture is never validated',
+                     'The filter checks syscall numbers without ever comparing data[4] (arch). ' \
+                     'Numbers mean different syscalls under another AUDIT_ARCH, so the checks can be ' \
+                     'dodged by invoking through a different ABI (e.g. i386 numbering on amd64).')]
+          elsif analysis.other_leaves.any? { |l| Explain::Verdict.label(l.ret) == 'ALLOW' }
+            [finding('Unlisted architectures reach ALLOW',
+                     'Some paths reach ALLOW on an architecture the filter does not explicitly ' \
+                     'check, so a different-ABI call can slip past the syscall-number rules.')]
+          else
+            []
+          end
+        end
+
+        # @!visibility private
+        def finding(title, detail)
+          Finding.new(id: 'arch-unchecked', severity: :high, arch: nil, title:, detail:,
+                      syscalls: [], condition: nil,
+                      remediation: 'Compare data[4] against your AUDIT_ARCH_* and KILL every ' \
+                                   'architecture you do not explicitly handle.')
+        end
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/audit/checks/dangerous_allow.rb
+++ b/lib/seccomp-tools/audit/checks/dangerous_allow.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/audit/catalog'
+require 'seccomp-tools/audit/finding'
+
+module SeccompTools
+  class Audit
+    module Checks
+      # A syscall a sandbox almost never wants ({Catalog#dangerous}) is reachable as +ALLOW+. One
+      # finding per syscall, carrying the argument condition (if any) under which it is allowed.
+      module DangerousAllow
+        module_function
+
+        # @param [Audit::Policy] policy
+        # @return [Array<Audit::Finding>]
+        def call(policy)
+          Catalog.dangerous(policy.arch_sym).filter_map do |name, meta|
+            nr = policy.number(name)
+            next unless nr && policy.reachable_as_allow?(nr)
+
+            cond = policy.condition_for(nr)
+            Finding.new(
+              id: 'dangerous-allow', severity: meta[:severity], arch: policy.arch_name,
+              title: "#{name} is allowed",
+              detail: "#{name} reaches ALLOW - #{meta[:why]}.",
+              syscalls: [name.to_s], condition: cond,
+              remediation: "Block #{name} unless the program genuinely needs it."
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/audit/checks/orw_chain.rb
+++ b/lib/seccomp-tools/audit/checks/orw_chain.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/audit/catalog'
+require 'seccomp-tools/audit/finding'
+
+module SeccompTools
+  class Audit
+    module Checks
+      # An open-family, a read-family and a write/send-family syscall are all reachable as +ALLOW+ -
+      # the classic "open the flag, read it, write it out" chain.
+      module OrwChain
+        module_function
+
+        # @param [Audit::Policy] policy
+        # @return [Array<Audit::Finding>]
+        def call(policy)
+          o = first_allowed(policy, Catalog::ORW[:open])
+          r = first_allowed(policy, Catalog::ORW[:read])
+          w = first_allowed(policy, Catalog::ORW[:write])
+          return [] unless o && r && w
+
+          [Finding.new(
+            id: 'orw-chain', severity: :high, arch: policy.arch_name,
+            title: 'Open, read and write are all allowed',
+            detail: "#{o}, #{r} and #{w} all reach ALLOW, so an arbitrary file (e.g. the flag) can " \
+                    'be opened, read, and written back out.',
+            syscalls: [o, r, w].map(&:to_s), condition: nil,
+            remediation: 'Drop the open-family syscalls if the program should not read arbitrary files.'
+          )]
+        end
+
+        # @!visibility private
+        def first_allowed(policy, names)
+          names.find { |n| (nr = policy.number(n)) && policy.reachable_as_allow?(nr) }
+        end
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/audit/checks/permissive_default.rb
+++ b/lib/seccomp-tools/audit/checks/permissive_default.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/audit/finding'
+
+module SeccompTools
+  class Audit
+    module Checks
+      # The catch-all action is +ALLOW+: a denylist, bypassable by anything the author forgot.
+      module PermissiveDefault
+        module_function
+
+        # @param [Audit::Policy] policy
+        # @return [Array<Audit::Finding>]
+        def call(policy)
+          return [] unless policy.default_label == 'ALLOW'
+
+          [Finding.new(
+            id: 'permissive-default', severity: :high, arch: policy.arch_name,
+            title: 'Default action is ALLOW (denylist)',
+            detail: 'Any syscall the filter does not explicitly block is allowed; a denylist is ' \
+                    'bypassable by any syscall the author overlooked.',
+            syscalls: [], condition: nil,
+            remediation: 'Use an allowlist: default to KILL/ERRNO and permit only the needed syscalls.'
+          )]
+        end
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/audit/checks/syscall_alt_gap.rb
+++ b/lib/seccomp-tools/audit/checks/syscall_alt_gap.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/audit/catalog'
+require 'seccomp-tools/audit/finding'
+
+module SeccompTools
+  class Audit
+    module Checks
+      # An equivalent-syscall gap: a group member is singled out for denial while a sibling with the
+      # same capability still reaches +ALLOW+ (blocked +execve+ but not +execveat+, +open+ but not
+      # +openat+, +fork+ but not +clone+).
+      module SyscallAltGap
+        module_function
+
+        # @param [Audit::Policy] policy
+        # @return [Array<Audit::Finding>]
+        def call(policy)
+          Catalog.alt_groups(policy.arch_sym).filter_map do |group, names|
+            present = names.filter_map { |n| [n, policy.number(n)] if policy.number(n) }
+            denied = present.select { |_n, nr| policy.explicitly_denied?(nr) }.map(&:first)
+            allowed = present.select { |_n, nr| policy.reachable_as_allow?(nr) }.map(&:first)
+            next if denied.empty? || allowed.empty?
+
+            finding(policy, group, denied, allowed)
+          end
+        end
+
+        # @!visibility private
+        def finding(policy, group, denied, allowed)
+          Finding.new(
+            id: 'syscall-alt-gap', severity: %i[exec open].include?(group) ? :high : :medium,
+            arch: policy.arch_name,
+            title: "#{denied.join('/')} blocked but #{allowed.join('/')} allowed",
+            detail: "#{denied.join(', ')} denied, but the equivalent #{allowed.join(', ')} reaches " \
+                    'ALLOW - same capability, different syscall number.',
+            syscalls: allowed.map(&:to_s), condition: nil,
+            remediation: "Deny every equivalent in the group: also block #{allowed.join(', ')}."
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/audit/checks/x32_guard.rb
+++ b/lib/seccomp-tools/audit/checks/x32_guard.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/audit/finding'
+
+module SeccompTools
+  class Audit
+    module Checks
+      # amd64's x32 ABI quirk: x32 syscalls share +AUDIT_ARCH_X86_64+ but number as +nr | 0x40000000+.
+      # Without a +sys_number >= 0x40000000+ (or +jset 0x40000000+) guard, a syscall blocked by its
+      # native number is still reachable through its x32 number. Registered only for amd64, so no
+      # other architecture is ever mis-flagged.
+      module X32Guard
+        module_function
+
+        # @param [Audit::Policy] policy
+        # @return [Array<Audit::Finding>]
+        def call(policy)
+          sharp = policy.table.filter_map do |name, nr|
+            next if name.to_s.start_with?('x32_')
+
+            x = policy.number(:"x32_#{name}")
+            name if x && policy.reachable_as_allow?(x) && !policy.reachable_as_allow?(nr)
+          end
+          return [] if sharp.empty?
+
+          [finding(policy, sharp)]
+        end
+
+        # @!visibility private
+        def finding(policy, sharp)
+          shown = sharp.first(8).map(&:to_s)
+          more = sharp.size > shown.size ? ", ... (+#{sharp.size - shown.size} more)" : ''
+          Finding.new(
+            id: 'x32-guard', severity: :high, arch: policy.arch_name,
+            title: 'x32 ABI is not guarded',
+            detail: 'Syscalls blocked by their native number are reachable via their x32 number ' \
+                    "(nr | 0x40000000): #{shown.join(', ')}#{more}.",
+            syscalls: shown, condition: nil,
+            remediation: 'After the arch check, KILL when sys_number >= 0x40000000 ' \
+                         '(or jset 0x40000000).'
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/audit/finding.rb
+++ b/lib/seccomp-tools/audit/finding.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SeccompTools
+  class Audit
+    # Severities, most to least severe. Drives ordering and (for +human+ output) coloring.
+    SEVERITIES = %i[high medium low].freeze
+
+    # One weakness reported by a {Check}: a stable +id+, a +severity+, a human +title+/+detail+, the
+    # architecture it applies to, the syscalls involved, an optional argument +condition+ under which
+    # it holds, and a one-line +remediation+.
+    Finding = Struct.new(:id, :severity, :title, :detail, :arch, :syscalls, :condition, :remediation,
+                         keyword_init: true) do
+      # Sort key: by severity, then id, then the affected syscalls.
+      # @return [Array]
+      def rank
+        [SEVERITIES.index(severity) || SEVERITIES.size, id, Array(syscalls).join(',')]
+      end
+
+      # @return [Hash] JSON-ready shape.
+      def to_h
+        { id:, severity:, title:, detail:, arch:, syscalls: Array(syscalls), condition:, remediation: }
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/audit/policy.rb
+++ b/lib/seccomp-tools/audit/policy.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/const'
+require 'seccomp-tools/explain/qword'
+require 'seccomp-tools/explain/renderer'
+require 'seccomp-tools/explain/verdict'
+require 'seccomp-tools/symbolic/constraint'
+
+module SeccompTools
+  class Audit
+    # One architecture's view of a filter: given a syscall number, which actions can an attacker
+    # reach? Built from that arch's section leaves (already arch-filtered by {Explain::Analysis}).
+    #
+    # A leaf is reachable for syscall +nr+ when every plain +sys_number+ fact on its path is satisfied
+    # by +nr+ - this one predicate covers +==+, ranges, and +jset+ bit-tests (so it sees an x32 guard
+    # written either way). Argument and opaque facts are *not* consulted: arguments are
+    # attacker-controlled and the executor already dropped self-contradictory paths, so a surviving
+    # leaf is reachable under some argument choice. The stance is deliberately conservative - "could an
+    # attacker reach this action?".
+    class Policy
+      SYS = Const::BPF::SeccompData::SYS_NUMBER
+
+      # @return [Integer?] The +AUDIT_ARCH+ value (+nil+ when the filter never branches on +arch+).
+      attr_reader :arch_val
+      # @return [Symbol?] The architecture symbol whose syscall names apply (+nil+ when unknown).
+      attr_reader :arch_sym
+      # @return [Object] Display title for this section (arch symbol or +0x... (unknown)+).
+      attr_reader :title
+      # @return [Array<Symbolic::Executor::Leaf>] This section's leaves.
+      attr_reader :leaves
+
+      # @param [Explain::Analysis] analysis
+      # @param [Array] section One +[arch_val, arch_sym, title, leaves]+ entry from {Explain::Analysis#sections}.
+      def initialize(analysis, section)
+        @analysis = analysis
+        @arch_val, @arch_sym, @title, @leaves = section
+        @fusion = @arch_sym && Explain::QwordFusion.new(@arch_sym)
+        @renderer = @fusion && Explain::Renderer.new(@fusion)
+      end
+
+      # A display name for this section's architecture (+"amd64"+, or +"0x... (unknown)"+).
+      # @return [String]
+      def arch_name
+        (@arch_sym || @title).to_s
+      end
+
+      # This arch's +name => number+ table, or +nil+ when the arch is unknown to seccomp-tools.
+      # @return [Hash{Symbol=>Integer}?]
+      def table
+        return @table if defined?(@table)
+
+        @table = @arch_sym && begin
+          Const::Syscall.const_get(@arch_sym.upcase)
+        rescue NameError
+          nil
+        end
+      end
+
+      # The number of syscall +name+ on this arch, or +nil+ if the arch lacks it.
+      # @param [Symbol] name
+      # @return [Integer?]
+      def number(name)
+        table && table[name]
+      end
+
+      # The action of the catch-all (default) path, e.g. +"ALLOW"+ / +"ERRNO(5)"+.
+      # @return [String?]
+      def default_label
+        @analysis.default_label(@leaves)
+      end
+
+      # The distinct actions reachable for syscall number +nr+.
+      # @param [Integer] nr
+      # @return [Array<String>]
+      def reachable_actions(nr)
+        reachable_leaves(nr).map { |l| Explain::Verdict.label(l.ret) }.uniq
+      end
+
+      # Can syscall +nr+ reach +ALLOW+?
+      # @param [Integer] nr
+      # @return [Boolean]
+      def reachable_as_allow?(nr)
+        reachable_leaves(nr).any? { |l| Explain::Verdict.label(l.ret) == 'ALLOW' }
+      end
+
+      # Was syscall +nr+ singled out for denial (a rule pins +sys_number == nr+ to a non-+ALLOW+
+      # action), as opposed to merely being absent from an allowlist? Distinguishes a real
+      # "blocked one equivalent but not another" gap from allowlist omissions.
+      # @param [Integer] nr
+      # @return [Boolean]
+      def explicitly_denied?(nr)
+        !reachable_as_allow?(nr) &&
+          @leaves.any? { |l| @analysis.facts(l).sys_eq == nr && Explain::Verdict.label(l.ret) != 'ALLOW' }
+      end
+
+      # The argument condition under which +nr+ reaches +action+, rendered like +explain+
+      # (+"filename == 0x..."+), or +nil+ when it is unconditional or the arch is unknown.
+      # @param [Integer] nr
+      # @param [String] action
+      # @return [String?]
+      def condition_for(nr, action = 'ALLOW')
+        return nil unless @renderer
+
+        ls = reachable_leaves(nr).select { |l| Explain::Verdict.label(l.ret) == action }
+        conds = @fusion.merge_or(ls.map { |l| @analysis.facts(l).residual })
+                       .map { |list| @renderer.conjunction(@fusion.fold(list), name_of(nr)) }.uniq
+        conds.include?('') ? nil : conds.join(' or ')
+      end
+
+      private
+
+      def name_of(nr)
+        table && table.invert[nr]
+      end
+
+      def reachable_leaves(nr)
+        @leaves.select { |l| sys_satisfied?(l, nr) }
+      end
+
+      def sys_satisfied?(leaf, nr)
+        leaf.path.all? do |c|
+          !c.plain_data_fact?(SYS) || Symbolic::Constraint.evaluate(nr, c.op, c.rhs.val)
+        end
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/audit/report.rb
+++ b/lib/seccomp-tools/audit/report.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/audit/finding'
+require 'seccomp-tools/util'
+
+module SeccompTools
+  class Audit
+    # The findings for one filter, rendered either as a human report or a JSON-ready hash.
+    class Report
+      # Severity => {Util.colorize} theme for the +[SEVERITY]+ tag.
+      SEVERITY_THEME = { high: :error, medium: :warn, low: :info }.freeze
+
+      # @param [String?] source Label for the audited filter.
+      # @param [Array<String>] arches The architectures covered.
+      # @param [Array<Finding>] findings
+      # @param [Boolean] truncated Whether the symbolic walk was cut short.
+      def initialize(source:, arches:, findings:, truncated:)
+        @source = source
+        @arches = arches
+        @findings = findings.sort_by(&:rank)
+        @truncated = truncated
+      end
+
+      # @return [Array<Finding>]
+      attr_reader :findings
+      # @return [Array<String>] The architectures covered.
+      attr_reader :arches
+
+      # The human report.
+      # @return [String]
+      def to_s
+        out = +''
+        out << "Seccomp audit of #{@source}\n" if @source
+        out << "Architectures: #{@arches.join(', ')}\n" unless @arches.empty?
+        # A truncated walk can only hide weaknesses, so it qualifies the whole report rather than
+        # being a finding of its own.
+        out << "WARNING: analysis truncated (filter too large); results may be incomplete.\n" if @truncated
+        return out << "\nNo weaknesses found.\n" if @findings.empty?
+
+        @findings.each { |f| out << render(f) }
+        out
+      end
+
+      # @return [Hash] JSON-ready shape for one filter.
+      def to_h
+        { source: @source, arches: @arches, truncated: @truncated, findings: @findings.map(&:to_h) }
+      end
+
+      private
+
+      def render(finding)
+        tag = Util.colorize("[#{finding.severity.to_s.upcase}]", t: SEVERITY_THEME[finding.severity])
+        arch = finding.arch ? " (#{Util.colorize(finding.arch, t: :arch)})" : ''
+        out = "\n#{tag} #{finding.title}#{arch}\n"
+        out << "    #{finding.detail}\n"
+        out << "    when: #{finding.condition}\n" if finding.condition
+        out << "    fix:  #{finding.remediation}\n" if finding.remediation
+        out
+      end
+    end
+  end
+end

--- a/spec/audit/policy_spec.rb
+++ b/spec/audit/policy_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/asm/asm'
+require 'seccomp-tools/audit/policy'
+require 'seccomp-tools/disasm/disasm'
+require 'seccomp-tools/explain/analysis'
+require 'seccomp-tools/symbolic/executor'
+
+describe SeccompTools::Audit::Policy do
+  def x32 = 0x40000000
+
+  # The first arch section's policy for an assembled filter.
+  def policy(src, arch = :amd64)
+    insts = SeccompTools::Disasm.to_bpf(SeccompTools::Asm.asm(src, arch:), arch).map(&:inst)
+    leaves, = SeccompTools::Symbolic::Executor.new(insts).run
+    analysis = SeccompTools::Explain::Analysis.new(leaves)
+    described_class.new(analysis, analysis.sections(arch).first)
+  end
+
+  let(:allowlist) do
+    policy(<<~ASM)
+      A = sys_number
+      A == write ? ok : next
+      return ERRNO(1)
+      ok:
+      return ALLOW
+    ASM
+  end
+
+  it 'resolves a syscall pinned by ==' do
+    expect(allowlist.reachable_as_allow?(allowlist.number(:write))).to be true
+    expect(allowlist.reachable_as_allow?(allowlist.number(:read))).to be false
+    expect(allowlist.reachable_actions(allowlist.number(:read))).to eq ['ERRNO(1)']
+    expect(allowlist.default_label).to eq 'ERRNO(1)'
+  end
+
+  it 'resolves a syscall bounded by a range' do
+    pol = policy(<<~ASM)
+      A = sys_number
+      A >= 0x10 ? dead : next
+      return ALLOW
+      dead:
+      return KILL
+    ASM
+    expect(pol.reachable_as_allow?(0x0f)).to be true
+    expect(pol.reachable_as_allow?(0x10)).to be false
+  end
+
+  describe '#explicitly_denied?' do
+    let(:denylist) do
+      policy(<<~ASM)
+        A = sys_number
+        A == execve ? dead : next
+        return ALLOW
+        dead:
+        return KILL
+      ASM
+    end
+
+    it 'is true for a syscall a rule pins to a non-ALLOW action' do
+      expect(denylist.explicitly_denied?(denylist.number(:execve))).to be true
+    end
+
+    it 'is false for a syscall merely absent from an allowlist' do
+      # read is not named here; it only reaches the default, so it is not "singled out".
+      expect(allowlist.explicitly_denied?(allowlist.number(:read))).to be false
+    end
+  end
+
+  describe 'x32 numbers' do
+    it 'reach the same action when no guard bounds the high bit' do
+      pol = policy(<<~ASM)
+        A = sys_number
+        A == execve ? dead : next
+        return ALLOW
+        dead:
+        return KILL
+      ASM
+      # native execve is blocked, but its x32 number falls through to the default ALLOW.
+      expect(pol.reachable_as_allow?(pol.number(:execve))).to be false
+      expect(pol.reachable_as_allow?(pol.number(:execve) | x32)).to be true
+    end
+
+    it 'are rejected by a jset 0x40000000 guard' do
+      pol = policy(<<~ASM)
+        A = sys_number
+        A & 0x40000000 ? dead : next
+        A == execve ? dead : next
+        return ALLOW
+        dead:
+        return KILL
+      ASM
+      expect(pol.reachable_as_allow?(pol.number(:execve) | x32)).to be false
+    end
+  end
+
+  it 'renders the argument condition under which a syscall is allowed' do
+    pol = policy(<<~ASM)
+      A = sys_number
+      A == socket ? next : dead
+      A = args[0]
+      A == 2 ? ok : dead
+      ok:
+      return ALLOW
+      dead:
+      return KILL
+    ASM
+    expect(pol.condition_for(pol.number(:socket))).to include('== 0x2')
+  end
+end

--- a/spec/audit_spec.rb
+++ b/spec/audit_spec.rb
@@ -1,0 +1,139 @@
+# encoding: ascii-8bit
+# frozen_string_literal: true
+
+require 'seccomp-tools/asm/asm'
+require 'seccomp-tools/audit'
+require 'seccomp-tools/disasm/disasm'
+require 'seccomp-tools/util'
+
+describe SeccompTools::Audit do
+  before { SeccompTools::Util.disable_color! }
+
+  def data(name)
+    File.join(__dir__, 'data', name)
+  end
+
+  def audit(raw, arch, source: nil)
+    insts = SeccompTools::Disasm.to_bpf(raw, arch).map(&:inst)
+    described_class.new(insts, arch:, source:).audit
+  end
+
+  def audit_file(name, arch)
+    audit(File.binread(data(name)), arch)
+  end
+
+  def audit_asm(src, arch = :amd64)
+    audit(SeccompTools::Asm.asm(src, arch:), arch)
+  end
+
+  def ids(report)
+    report.findings.map(&:id).uniq.sort
+  end
+
+  it 'reports nothing for a clean allowlist (arch checked, x32 guarded, default ERRNO)' do
+    report = audit_file('libseccomp.bpf', :amd64)
+    expect(report.findings).to eq []
+    expect(report.to_s).to include('No weaknesses found')
+  end
+
+  it 'flags a no-arch-check, permissive, x32-unguarded denylist' do
+    report = audit_file('twctf-2016-diary.bpf', :amd64)
+    expect(ids(report)).to include('arch-unchecked', 'dangerous-allow', 'permissive-default', 'x32-guard')
+  end
+
+  it 'runs the general checks on non-amd64 architectures, but never x32 there' do
+    report = audit_file('twctf-2016-diary.bpf', :i386)
+    # permissive-default / arch-unchecked are structural, so they fire on i386 too...
+    expect(ids(report)).to include('arch-unchecked', 'permissive-default')
+    # ...while x32 is amd64-only and must not be reported for i386.
+    expect(ids(report)).not_to include('x32-guard')
+  end
+
+  it 'flags a filter that checks arch but lets an unlisted one reach ALLOW' do
+    report = audit_asm(<<~ASM)
+      A = arch
+      A == 0xc000003e ? next : other
+      A = sys_number
+      A == execve ? dead : next
+      return ERRNO(1)
+      other:
+      return ALLOW
+      dead:
+      return KILL
+    ASM
+    arch = report.findings.find { |f| f.id == 'arch-unchecked' }
+    expect(arch.title).to include('Unlisted architectures reach ALLOW')
+  end
+
+  it 'never flags x32 on an architecture that has no x32 ABI (aarch64)' do
+    report = audit_file('DEF-CON-2020-bdooos.bpf', :aarch64)
+    expect(report.arches).to eq ['aarch64']
+    expect(ids(report)).not_to include('x32-guard')
+  end
+
+  it 'audits every architecture of a multi-arch filter' do
+    report = audit_file('tctf-2023-nothing-is-true.bpf', :amd64)
+    expect(report.arches).to contain_exactly('amd64', 'i386')
+  end
+
+  it 'detects an equivalent-syscall gap (execve blocked, execveat allowed)' do
+    report = audit_asm(<<~ASM)
+      A = sys_number
+      A == execve ? dead : next
+      A == execveat ? ok : next
+      return KILL
+      ok:
+      return ALLOW
+      dead:
+      return KILL
+    ASM
+    gap = report.findings.find { |f| f.id == 'syscall-alt-gap' }
+    expect(gap).not_to be_nil
+    expect(gap.severity).to be :high
+    expect(gap.syscalls).to eq %w[execveat]
+  end
+
+  it 'detects the open/read/write chain' do
+    report = audit_asm(<<~ASM)
+      A = sys_number
+      A == open ? ok : next
+      A == read ? ok : next
+      A == write ? ok : next
+      return KILL
+      ok:
+      return ALLOW
+    ASM
+    orw = report.findings.find { |f| f.id == 'orw-chain' }
+    expect(orw).not_to be_nil
+    expect(orw.syscalls).to eq %w[open read write]
+  end
+
+  it 'does not flag x32 for an allowlist whose native rules already reject x32 numbers' do
+    # A default-KILL allowlist matches only native numbers, so nr|0x40000000 falls through to KILL.
+    report = audit_asm(<<~ASM)
+      A = arch
+      A == 0xc000003e ? next : dead
+      A = sys_number
+      A == write ? ok : next
+      return KILL
+      ok:
+      return ALLOW
+      dead:
+      return KILL
+    ASM
+    expect(ids(report)).not_to include('x32-guard')
+  end
+
+  it 'warns when the analysis was truncated, rather than reporting it as a weakness' do
+    stub_const('SeccompTools::Symbolic::Executor::STEP_CAP', 1)
+    report = audit_file('libseccomp.bpf', :amd64)
+    expect(report.to_s).to include('WARNING: analysis truncated')
+    expect(report.to_h[:truncated]).to be true
+    expect(report.findings.map(&:severity).uniq - described_class::SEVERITIES).to eq []
+  end
+
+  it 'only reports the severities it declares' do
+    report = audit_file('twctf-2016-diary.bpf', :amd64)
+    expect(report.findings.map(&:severity).uniq).to all(satisfy { |s| described_class::SEVERITIES.include?(s) })
+  end
+end


### PR DESCRIPTION
Assess a seccomp filter for escape routes and report them with severities: missing arch validation, a permissive (denylist) default, equivalent-syscall gaps, an open/read/write chain, dangerous syscalls reachable as ALLOW, and (amd64) an unguarded x32 ABI.

Reuses the explain symbolic engine through a per-arch reachability resolver. Every supported architecture is assessed; architecture-specific quirks are registered per arch, so a newly learned one is a single entry.