### PR TITLE
Add the `audit` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Some features might be CTF-specific, but also useful for analyzing seccomp of re
 * Asm - Makes writing seccomp rules similar to writing codes.
 * Emu - Emulates seccomp rules.
 * Explain - Summarizes a filter as a per-action policy (which syscalls are allowed/killed, and when).
+* Audit - Scans a filter for weaknesses and escape routes (missing arch/x32 guards, dangerous syscalls, ...).
 * Supports multi-architecture.
 
 ## Installation
@@ -449,6 +450,121 @@ $ seccomp-tools explain spec/data/tctf-2023-nothing-is-true.bpf -a amd64
 #     <default> (any other syscall)
 #
 # Other architectures: KILL
+```
+
+### Audit
+
+Scans a filter for weaknesses and likely escape routes - a missing architecture or x32 guard, a
+permissive (denylist) default, equivalent-syscall gaps (e.g. `execve` blocked but `execveat` not),
+an open/read/write chain, or dangerous syscalls reachable as `ALLOW` - and reports each with a
+severity. It runs on every supported architecture (architecture-specific quirks like amd64's x32 are
+applied only where they exist), and takes the same input as `explain` (a BPF file, an executable, or
+`--pid`).
+```bash
+$ seccomp-tools audit --help
+# audit - Assess a seccomp filter for weaknesses and escape routes.
+#
+# Usage: seccomp-tools audit [options] [BPF_FILE|EXEC]
+#     -c, --sh-exec <command>          Executes the given command (via sh) and audits its seccomp.
+#                                      Use this to pass arguments or pipe things to the execution file.
+#                                      e.g. use `-c "./bin > /dev/null"` to keep the program output out of the result.
+#                                      Takes precedence over the positional argument.
+#     -l, --limit LIMIT                Audit only the first LIMIT installed filters.
+#                                      Only meaningful when the input is an executable or --pid. Default: 1
+#                                      An executable is killed once it reaches LIMIT.
+#     -p, --pid PID                    Audit the seccomp filters installed on an existing process.
+#                                      You must have CAP_SYS_ADMIN (e.g. be root) to use this option.
+#     -t, --timeout SEC                Timeout (seconds) for the execution. Default: no timeout
+#                                      This option is ignored when --pid is given.
+#     -a, --arch ARCH                  Specify architecture.
+#                                      Supported architectures are <aarch64|amd64|i386|riscv64|s390x>.
+#                                      Default: auto-detected from the host machine.
+#                                      Set it when the filter targets an architecture other than the host.
+#                                      With an executable or --pid the architecture is auto-detected instead.
+#     -f, --format FORMAT              Output format, one of <human|json>.
+#                                      Default: human
+```
+
+Auditing a denylist with several escape routes (the TokyoWesterns CTF 2016 "diary" filter):
+```bash
+$ seccomp-tools audit spec/data/twctf-2016-diary.bpf -a amd64
+# Seccomp audit of spec/data/twctf-2016-diary.bpf
+# Architectures: amd64
+#
+# [HIGH] Architecture is never validated
+#     The filter checks syscall numbers without ever comparing data[4] (arch). Numbers mean different syscalls under another AUDIT_ARCH, so the checks can be dodged by invoking through a different ABI (e.g. i386 numbering on amd64).
+#     fix:  Compare data[4] against your AUDIT_ARCH_* and KILL every architecture you do not explicitly handle.
+#
+# [HIGH] process_vm_readv is allowed (amd64)
+#     process_vm_readv reaches ALLOW - read another process's memory.
+#     fix:  Block process_vm_readv unless the program genuinely needs it.
+#
+# [HIGH] process_vm_writev is allowed (amd64)
+#     process_vm_writev reaches ALLOW - write another process's memory.
+#     fix:  Block process_vm_writev unless the program genuinely needs it.
+#
+# [HIGH] ptrace is allowed (amd64)
+#     ptrace reaches ALLOW - inspect/inject into other processes.
+#     fix:  Block ptrace unless the program genuinely needs it.
+#
+# [HIGH] Default action is ALLOW (denylist) (amd64)
+#     Any syscall the filter does not explicitly block is allowed; a denylist is bypassable by any syscall the author overlooked.
+#     fix:  Use an allowlist: default to KILL/ERRNO and permit only the needed syscalls.
+#
+# [HIGH] x32 ABI is not guarded (amd64)
+#     Syscalls blocked by their native number are reachable via their x32 number (nr | 0x40000000): open, clone, fork, vfork, execve, creat, openat, execveat.
+#     fix:  After the arch check, KILL when sys_number >= 0x40000000 (or jset 0x40000000).
+#
+# [MEDIUM] connect is allowed (amd64)
+#     connect reaches ALLOW - network access (exfiltration).
+#     fix:  Block connect unless the program genuinely needs it.
+#
+# [MEDIUM] socket is allowed (amd64)
+#     socket reaches ALLOW - network access (exfiltration).
+#     fix:  Block socket unless the program genuinely needs it.
+```
+
+Use `--format json` for CI or tooling:
+```bash
+$ seccomp-tools audit spec/data/gctf-2019-quals-caas.bpf -a amd64 -f json
+# {
+#   "stacked_filters": 1,
+#   "reports": [
+#     {
+#       "source": "spec/data/gctf-2019-quals-caas.bpf",
+#       "arches": [
+#         "amd64"
+#       ],
+#       "truncated": false,
+#       "findings": [
+#         {
+#           "id": "dangerous-allow",
+#           "severity": "medium",
+#           "title": "connect is allowed",
+#           "detail": "connect reaches ALLOW - network access (exfiltration).",
+#           "arch": "amd64",
+#           "syscalls": [
+#             "connect"
+#           ],
+#           "condition": null,
+#           "remediation": "Block connect unless the program genuinely needs it."
+#         },
+#         {
+#           "id": "dangerous-allow",
+#           "severity": "medium",
+#           "title": "socket is allowed",
+#           "detail": "socket reaches ALLOW - network access (exfiltration).",
+#           "arch": "amd64",
+#           "syscalls": [
+#             "socket"
+#           ],
+#           "condition": "family == 0x2 && type == 0x1 && protocol == 0x0",
+#           "remediation": "Block socket unless the program genuinely needs it."
+#         }
+#       ]
+#     }
+#   ]
+# }
 ```
 
 ## Screenshots

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -24,6 +24,7 @@ Some features might be CTF-specific, but also useful for analyzing seccomp of re
 * Asm - Makes writing seccomp rules similar to writing codes.
 * Emu - Emulates seccomp rules.
 * Explain - Summarizes a filter as a per-action policy (which syscalls are allowed/killed, and when).
+* Audit - Scans a filter for weaknesses and escape routes (missing arch/x32 guards, dangerous syscalls, ...).
 * Supports multi-architecture.
 
 ## Installation
@@ -124,6 +125,28 @@ A more involved example - the 0CTF/TCTF 2023 "Nothing is True" filter, which has
 allowlists and argument checks on `open`, `mmap` and `execve`:
 ```bash
 SHELL_OUTPUT_OF(seccomp-tools explain spec/data/tctf-2023-nothing-is-true.bpf -a amd64)
+```
+
+### Audit
+
+Scans a filter for weaknesses and likely escape routes - a missing architecture or x32 guard, a
+permissive (denylist) default, equivalent-syscall gaps (e.g. `execve` blocked but `execveat` not),
+an open/read/write chain, or dangerous syscalls reachable as `ALLOW` - and reports each with a
+severity. It runs on every supported architecture (architecture-specific quirks like amd64's x32 are
+applied only where they exist), and takes the same input as `explain` (a BPF file, an executable, or
+`--pid`).
+```bash
+SHELL_OUTPUT_OF(seccomp-tools audit --help)
+```
+
+Auditing a denylist with several escape routes (the TokyoWesterns CTF 2016 "diary" filter):
+```bash
+SHELL_OUTPUT_OF(seccomp-tools audit spec/data/twctf-2016-diary.bpf -a amd64)
+```
+
+Use `--format json` for CI or tooling:
+```bash
+SHELL_OUTPUT_OF(seccomp-tools audit spec/data/gctf-2019-quals-caas.bpf -a amd64 -f json)
 ```
 
 ## Screenshots

--- a/lib/seccomp-tools/cli/audit.rb
+++ b/lib/seccomp-tools/cli/audit.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require 'seccomp-tools/audit'
+require 'seccomp-tools/cli/base'
+require 'seccomp-tools/cli/filter_input'
+require 'seccomp-tools/disasm/disasm'
+require 'seccomp-tools/logger'
+
+module SeccompTools
+  module CLI
+    # Handle 'audit' command.
+    class Audit < Base
+      include FilterInput
+
+      # Summary of this command.
+      SUMMARY = 'Assess a seccomp filter for weaknesses and escape routes.'
+      # Usage of this command.
+      USAGE = "audit - #{SUMMARY}\n\nUsage: seccomp-tools audit [options] [BPF_FILE|EXEC]".freeze
+
+      # Instantiate an {Audit} object.
+      #
+      # Takes the same arguments as {Base#initialize}.
+      def initialize(*)
+        super
+        option[:format] = :human
+      end
+
+      # Define option parser.
+      # @return [OptionParser]
+      #   The parser of this command's options.
+      def parser
+        @parser ||= OptionParser.new do |opt|
+          opt.banner = usage
+          option_filter_source(opt, 'audit')
+          option_arch(opt, 'With an executable or --pid the architecture is auto-detected instead.')
+
+          opt.on('-f', '--format FORMAT', %i[human json], 'Output format, one of <human|json>.',
+                 'Default: human') do |f|
+            option[:format] = f
+          end
+        end
+      end
+
+      # Reads the filter(s) from a BPF file, an executable, or an existing process, then reports the
+      # weaknesses of each.
+      # @return [void]
+      def handle
+        return unless super
+
+        filters = collect_filters
+        return if filters.empty?
+
+        option[:format] == :json ? emit_json(filters) : emit_human(filters)
+      end
+
+      private
+
+      # Prints each filter's report, warning first when several filters stack.
+      def emit_human(filters)
+        if filters.size > 1
+          Logger.warn("#{filters.size} filters are installed; they stack, so a syscall must pass every one " \
+                      '(most restrictive wins). Each is audited separately below.')
+        end
+        each_report(filters) { |report| output { report.to_s } }
+      end
+
+      # Prints one JSON document describing every stacked filter.
+      def emit_json(filters)
+        reports = []
+        each_report(filters) { |report| reports << report.to_h }
+        output { "#{JSON.pretty_generate(stacked_filters: filters.size, reports:)}\n" }
+      end
+
+      # Yields the {Audit::Report} of each filter, labelling stacked filters like +explain+ does.
+      def each_report(filters)
+        filters.each_with_index do |(raw, arch, source), idx|
+          label = filters.size > 1 ? "#{source} (filter ##{idx})" : source
+          insts = SeccompTools::Disasm.to_bpf(raw, arch).map(&:inst)
+          yield SeccompTools::Audit.new(insts, arch:, source: label).audit
+        end
+      end
+    end
+  end
+end

--- a/lib/seccomp-tools/cli/cli.rb
+++ b/lib/seccomp-tools/cli/cli.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'seccomp-tools/cli/asm'
+require 'seccomp-tools/cli/audit'
 require 'seccomp-tools/cli/disasm'
 require 'seccomp-tools/cli/dump'
 require 'seccomp-tools/cli/emu'
@@ -13,6 +14,7 @@ module SeccompTools
     # Handled commands
     COMMANDS = {
       'asm' => SeccompTools::CLI::Asm,
+      'audit' => SeccompTools::CLI::Audit,
       'disasm' => SeccompTools::CLI::Disasm,
       'dump' => SeccompTools::CLI::Dump,
       'emu' => SeccompTools::CLI::Emu,

--- a/spec/cli/audit_spec.rb
+++ b/spec/cli/audit_spec.rb
@@ -1,0 +1,73 @@
+# encoding: ascii-8bit
+# frozen_string_literal: true
+
+require 'json'
+require 'stringio'
+
+require 'seccomp-tools/cli/audit'
+require 'seccomp-tools/util'
+
+describe SeccompTools::CLI::Audit do
+  before { SeccompTools::Util.disable_color! }
+
+  def data(name)
+    File.join(__dir__, '..', 'data', name)
+  end
+
+  def capture(argv)
+    io = StringIO.new
+    orig = $stdout
+    $stdout = io
+    described_class.new(argv).handle
+    io.string
+  ensure
+    $stdout = orig
+  end
+
+  it 'prints a human report' do
+    out = capture([data('twctf-2016-diary.bpf'), '-a', 'amd64'])
+    expect(out).to include('Seccomp audit of', '[HIGH] Architecture is never validated')
+  end
+
+  it 'reports a clean allowlist as having no weaknesses' do
+    out = capture([data('libseccomp.bpf'), '-a', 'amd64'])
+    expect(out).to include('No weaknesses found')
+  end
+
+  it 'emits a valid JSON document with --format json' do
+    doc = JSON.parse(capture([data('gctf-2019-quals-caas.bpf'), '-a', 'amd64', '-f', 'json']))
+    expect(doc['stacked_filters']).to eq 1
+    report = doc['reports'].first
+    expect(report['arches']).to eq ['amd64']
+    expect(report['findings'].map { |f| f['id'] }).to include('dangerous-allow')
+    socket = report['findings'].find { |f| f['syscalls'] == ['socket'] }
+    expect(socket['severity']).to eq 'medium'
+    expect(socket['condition']).to include('== 0x2')
+  end
+
+  it 'reads a raw filter from stdin' do
+    allow($stdin).to receive(:read).and_return(File.binread(data('twctf-2016-diary.bpf')))
+    out = capture(['-', '-a', 'amd64'])
+    expect(out).to include('Seccomp audit of <STDIN>', 'x32 ABI is not guarded')
+  end
+
+  it 'warns about and separately labels several stacked filters' do
+    f0 = File.binread(data('twctf-2016-diary.bpf'))
+    f1 = File.binread(data('libseccomp.bpf'))
+    stub_const('SeccompTools::Dumper::SUPPORTED', true)
+    allow(SeccompTools::Dumper).to receive(:dump) do |*, **, &blk|
+      [blk.call(f0, :amd64), blk.call(f1, :amd64)]
+    end
+    out = capture(['-c', './x', '-a', 'amd64', '-l', '2', '-t', '1.5'])
+    expect(out).to include('filters are installed', '(filter #0)', '(filter #1)')
+  end
+
+  it 'audits filters dumped from a running process via --pid' do
+    stub_const('SeccompTools::Dumper::SUPPORTED', true)
+    allow(SeccompTools::Dumper).to receive(:dump_by_pid) do |*, &blk|
+      [blk.call(File.binread(data('twctf-2016-diary.bpf')), nil)]
+    end
+    out = capture(['-p', '1234', '-a', 'amd64'])
+    expect(out).to include('x32 ABI is not guarded')
+  end
+end

--- a/spec/cli/help_spec.rb
+++ b/spec/cli/help_spec.rb
@@ -10,6 +10,7 @@ Usage: seccomp-tools [--version] [--help] <command> [<options>]
 List of commands:
 
 	asm	Seccomp bpf assembler.
+	audit	Assess a seccomp filter for weaknesses and escape routes.
 	disasm	Disassemble seccomp bpf.
 	dump	Automatically dump seccomp bpf from execution file(s).
 	emu	Emulate seccomp rules.
@@ -46,6 +47,32 @@ Usage: seccomp-tools dump [EXEC] [options]
                                      If multiple seccomp syscalls have been invoked (see --limit),
                                      results will be written to FILE, FILE_1, FILE_2.. etc.
                                      For example, "--output out.bpf" and the output files are out.bpf, out_1.bpf, ...
+EOS
+  end
+
+  it 'help audit' do
+    expect { described_class.work(%w[audit --help]) }.to output(<<EOS).to_stdout
+audit - Assess a seccomp filter for weaknesses and escape routes.
+
+Usage: seccomp-tools audit [options] [BPF_FILE|EXEC]
+    -c, --sh-exec <command>          Executes the given command (via sh) and audits its seccomp.
+                                     Use this to pass arguments or pipe things to the execution file.
+                                     e.g. use `-c "./bin > /dev/null"` to keep the program output out of the result.
+                                     Takes precedence over the positional argument.
+    -l, --limit LIMIT                Audit only the first LIMIT installed filters.
+                                     Only meaningful when the input is an executable or --pid. Default: 1
+                                     An executable is killed once it reaches LIMIT.
+    -p, --pid PID                    Audit the seccomp filters installed on an existing process.
+                                     You must have CAP_SYS_ADMIN (e.g. be root) to use this option.
+    -t, --timeout SEC                Timeout (seconds) for the execution. Default: no timeout
+                                     This option is ignored when --pid is given.
+    -a, --arch ARCH                  Specify architecture.
+                                     Supported architectures are <aarch64|amd64|i386|riscv64|s390x>.
+                                     Default: auto-detected from the host machine.
+                                     Set it when the filter targets an architecture other than the host.
+                                     With an executable or --pid the architecture is auto-detected instead.
+    -f, --format FORMAT              Output format, one of <human|json>.
+                                     Default: human
 EOS
   end
 


### PR DESCRIPTION
Expose the audit engine as a command, taking the same input as explain (a BPF file, stdin, an executable, or --pid) and reporting findings as a human report or --format json. Documented in the README.