### PR TITLE
Color syscall names and wrap findings to 120 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,8 @@ $ seccomp-tools audit spec/data/twctf-2016-diary.bpf -a amd64
 # Architectures: amd64
 #
 # [HIGH] Architecture is never validated
-#     The filter checks syscall numbers without ever comparing data[4] (arch). Numbers mean different syscalls under another AUDIT_ARCH, so the checks can be dodged by invoking through a different ABI (e.g. i386 numbering on amd64).
+#     The filter checks syscall numbers without ever comparing data[4] (arch). Numbers mean different syscalls under
+#     another AUDIT_ARCH, so the checks can be dodged by invoking through a different ABI (e.g. i386 numbering on amd64).
 #     fix:  Compare data[4] against your AUDIT_ARCH_* and KILL every architecture you do not explicitly handle.
 #
 # [HIGH] process_vm_readv is allowed (amd64)
@@ -508,11 +509,13 @@ $ seccomp-tools audit spec/data/twctf-2016-diary.bpf -a amd64
 #     fix:  Block ptrace unless the program genuinely needs it.
 #
 # [HIGH] Default action is ALLOW (denylist) (amd64)
-#     Any syscall the filter does not explicitly block is allowed; a denylist is bypassable by any syscall the author overlooked.
+#     Any syscall the filter does not explicitly block is allowed; a denylist is bypassable by any syscall the author
+#     overlooked.
 #     fix:  Use an allowlist: default to KILL/ERRNO and permit only the needed syscalls.
 #
 # [HIGH] x32 ABI is not guarded (amd64)
-#     Syscalls blocked by their native number are reachable via their x32 number (nr | 0x40000000): open, clone, fork, vfork, execve, creat, openat, execveat.
+#     Syscalls blocked by their native number are reachable via their x32 number (nr | 0x40000000): open, clone, fork,
+#     vfork, execve, creat, openat, execveat.
 #     fix:  After the arch check, KILL when sys_number >= 0x40000000 (or jset 0x40000000).
 #
 # [MEDIUM] connect is allowed (amd64)

--- a/lib/seccomp-tools/audit/checks/orw_chain.rb
+++ b/lib/seccomp-tools/audit/checks/orw_chain.rb
@@ -21,11 +21,13 @@ module SeccompTools
 
           [Finding.new(
             id: 'orw-chain', severity: :high, arch: policy.arch_name,
-            title: 'Open, read and write are all allowed',
-            detail: "#{o}, #{r} and #{w} all reach ALLOW, so an arbitrary file (e.g. the flag) can " \
-                    'be opened, read, and written back out.',
+            title: 'A file can be opened and its contents copied out',
+            # The syscall names are painted wherever they appear, so keep them out of prose that
+            # merely describes the actions - only name one where the syscall itself is meant.
+            detail: "#{o}, #{r} and #{w} all reach ALLOW, so the contents of an arbitrary file " \
+                    '(e.g. the flag) can be copied straight back out.',
             syscalls: [o, r, w].map(&:to_s), condition: nil,
-            remediation: 'Drop the open-family syscalls if the program should not read arbitrary files.'
+            remediation: 'Deny the open-family syscalls unless the program genuinely needs arbitrary files.'
           )]
         end
 

--- a/lib/seccomp-tools/audit/checks/syscall_alt_gap.rb
+++ b/lib/seccomp-tools/audit/checks/syscall_alt_gap.rb
@@ -33,7 +33,8 @@ module SeccompTools
             title: "#{denied.join('/')} blocked but #{allowed.join('/')} allowed",
             detail: "#{denied.join(', ')} denied, but the equivalent #{allowed.join(', ')} reaches " \
                     'ALLOW - same capability, different syscall number.',
-            syscalls: allowed.map(&:to_s), condition: nil,
+            # Both sides: the finding is about the pair, and the detail says which is which.
+            syscalls: (denied + allowed).map(&:to_s), condition: nil,
             remediation: "Deny every equivalent in the group: also block #{allowed.join(', ')}."
           )
         end

--- a/lib/seccomp-tools/audit/report.rb
+++ b/lib/seccomp-tools/audit/report.rb
@@ -10,6 +10,9 @@ module SeccompTools
       # Severity => {Util.colorize} theme for the +[SEVERITY]+ tag.
       SEVERITY_THEME = { high: :error, medium: :warn, low: :info }.freeze
 
+      # Widest a rendered line may get, so a finding reads without wrapping on a standard terminal.
+      WIDTH = 120
+
       # @param [String?] source Label for the audited filter.
       # @param [Array<String>] arches The architectures covered.
       # @param [Array<Finding>] findings
@@ -51,11 +54,44 @@ module SeccompTools
       def render(finding)
         tag = Util.colorize("[#{finding.severity.to_s.upcase}]", t: SEVERITY_THEME[finding.severity])
         arch = finding.arch ? " (#{Util.colorize(finding.arch, t: :arch)})" : ''
-        out = "\n#{tag} #{finding.title}#{arch}\n"
-        out << "    #{finding.detail}\n"
-        out << "    when: #{finding.condition}\n" if finding.condition
-        out << "    fix:  #{finding.remediation}\n" if finding.remediation
+        names = finding.syscalls
+        out = "\n#{tag} #{highlight(finding.title, names)}#{arch}\n"
+        out << paragraph(finding.detail, names, '    ', '    ')
+        out << paragraph(finding.condition, names, '    when: ', '          ') if finding.condition
+        out << paragraph(finding.remediation, names, '    fix:  ', '          ') if finding.remediation
         out
+      end
+
+      # +text+ wrapped to {WIDTH} columns, its first line prefixed with +first+ and the rest with
+      # +hang+ so they read as one block. Wrapping is measured before coloring, so the invisible
+      # escape codes never count towards the width.
+      # @return [String]
+      def paragraph(text, names, first, hang)
+        lines = []
+        indent = first
+        line = nil
+        text.to_s.split(/\s+/).each do |word|
+          if line.nil?
+            line = word
+          elsif indent.size + line.size + 1 + word.size <= WIDTH
+            line = "#{line} #{word}"
+          else
+            lines << (indent + line)
+            indent = hang
+            line = word
+          end
+        end
+        lines << (indent + line) if line
+        lines.map { |l| "#{highlight(l, names)}\n" }.join
+      end
+
+      # Paints the syscall names a finding is about wherever they appear in +text+, in the same color
+      # disasm gives them. Whole words only, so +read+ leaves +process_vm_readv+ alone.
+      # @return [String]
+      def highlight(text, names)
+        Array(names).uniq.reduce(text) do |painted, name|
+          painted.gsub(/\b#{Regexp.escape(name)}\b/) { Util.colorize(name, t: :syscall) }
+        end
       end
     end
   end

--- a/spec/audit_spec.rb
+++ b/spec/audit_spec.rb
@@ -90,7 +90,7 @@ describe SeccompTools::Audit do
     gap = report.findings.find { |f| f.id == 'syscall-alt-gap' }
     expect(gap).not_to be_nil
     expect(gap.severity).to be :high
-    expect(gap.syscalls).to eq %w[execveat]
+    expect(gap.syscalls).to eq %w[execve execveat]
   end
 
   it 'detects the open/read/write chain' do


### PR DESCRIPTION
Paint the syscalls a finding is about in the same color disasm gives them, matching them as whole words so read leaves process_vm_readv alone. Wrap the prose to 120 columns, measured before coloring so the escapes do not count, with continuation lines hanging under the label.

Word the ORW finding so a syscall name appears only where the syscall is meant, now that every mention is painted.