### PR TITLE
Fail fast when the host arch is undetectable

### DIFF
--- a/lib/seccomp-tools/audit/policy.rb
+++ b/lib/seccomp-tools/audit/policy.rb
@@ -44,16 +44,15 @@ module SeccompTools
         (@arch_sym || @title).to_s
       end
 
-      # This arch's +name => number+ table, or +nil+ when the arch is unknown to seccomp-tools.
+      # This arch's +name => number+ table, or +nil+ when the section has no known architecture.
+      #
+      # +@arch_sym+ is always +nil+ or a supported architecture (the CLI rejects an undetectable host
+      # before we get here), so the table lookup never fails.
       # @return [Hash{Symbol=>Integer}?]
       def table
         return @table if defined?(@table)
 
-        @table = @arch_sym && begin
-          Const::Syscall.const_get(@arch_sym.upcase)
-        rescue NameError
-          nil
-        end
+        @table = @arch_sym && Const::Syscall.const_get(@arch_sym.upcase)
       end
 
       # The number of syscall +name+ on this arch, or +nil+ if the arch lacks it.

--- a/lib/seccomp-tools/cli/base.rb
+++ b/lib/seccomp-tools/cli/base.rb
@@ -37,7 +37,21 @@ module SeccompTools
         return CLI.show(parser.help) if argv.empty? || %w[-h --help].intersect?(argv)
 
         parser.parse!(argv)
-        option[:arch] ||= Util.system_arch
+
+        # Fill in the architecture from the host when --arch was not given. A command that offers
+        # --arch needs a concrete architecture to name syscalls; if the host CPU is one seccomp-tools
+        # does not recognize, auto-detection cannot supply one, so fail with a clear message instead
+        # of letting :unknown reach a syscall-table lookup and raise deep down.
+        return true unless option[:arch].nil?
+
+        arch = Util.system_arch
+        if arch == :unknown && @arch_option_offered
+          Logger.error('Could not detect the host architecture; specify one with ' \
+                       "--arch <#{Util.supported_archs.join('|')}>.")
+          return false
+        end
+
+        option[:arch] = arch
         true
       end
 
@@ -117,6 +131,7 @@ module SeccompTools
       #   Extra description lines appended after the default ones, for command-specific guidance.
       # @return [void]
       def option_arch(opt, *extra_desc)
+        @arch_option_offered = true
         supported = Util.supported_archs
         opt.on('-a', '--arch ARCH', supported, 'Specify architecture.',
                "Supported architectures are <#{supported.join('|')}>.",

--- a/spec/cli/disasm_spec.rb
+++ b/spec/cli/disasm_spec.rb
@@ -109,4 +109,17 @@ EOS
 0011: return ALLOW
     EOS
   end
+
+  it 'fails clearly when the host arch is unrecognized and no --arch is given' do
+    allow(SeccompTools::Util).to receive(:system_arch).and_return(:unknown)
+    # It reports the error and stops, rather than crashing on a :UNKNOWN syscall-table lookup.
+    expect { described_class.new([@bpf]).handle }
+      .to output(/\A\[ERROR\] Could not detect the host architecture; specify one with --arch <[^>]+>\.\n\z/)
+      .to_stdout
+  end
+
+  it 'honors an explicit --arch even when the host arch is unrecognized' do
+    allow(SeccompTools::Util).to receive(:system_arch).and_return(:unknown)
+    expect { described_class.new([@bpf, '-a', 'amd64']).handle }.to output(/A = sys_number/).to_stdout
+  end
 end


### PR DESCRIPTION
Commands that offer --arch need a concrete architecture to name syscalls. On an unrecognized host CPU, auto-detection yields :unknown, which used to reach a :UNKNOWN syscall-table lookup and raise NameError deep in disasm, emu, asm and explain. Detect it up front and print a clear message telling the user to pass --arch.

With that guarantee, drop the rescue in Audit::Policy#table: arch_sym is now always nil or a supported arch, so the lookup never fails.