### PR TITLE
Explain why BPF_MOD is unsupported

### DIFF
--- a/lib/seccomp-tools/const.rb
+++ b/lib/seccomp-tools/const.rb
@@ -119,7 +119,8 @@ module SeccompTools
         lsh: 0x60,
         rsh: 0x70,
         neg: 0x80,
-        # mod: 0x90, # not supported
+        # mod (0x90) is intentionally omitted: the kernel's seccomp_check_filter() allowlist rejects
+        # BPF_MOD (EINVAL), so it can never appear in a loadable seccomp filter.
         xor: 0xa0
       }.freeze
 

--- a/lib/seccomp-tools/instruction/alu.rb
+++ b/lib/seccomp-tools/instruction/alu.rb
@@ -19,7 +19,7 @@ module SeccompTools
         lsh: :<<,
         rsh: :>>,
         # neg: :-, # should not be invoked
-        # mod: :%, # unsupported
+        # mod: :%, # the kernel rejects BPF_MOD (see Const::BPF::OP), so it never reaches here
         xor: :^
       }.freeze
       # Decompile instruction.


### PR DESCRIPTION
The kernel's seccomp_check_filter() allowlist rejects BPF_MOD (EINVAL), so it can never appear in a loadable filter - note that where the opcode is omitted, so it is not mistaken for an oversight.