### PR TITLE
Emulate division by zero as KILL instead of crashing

### DIFF
--- a/lib/seccomp-tools/emulator.rb
+++ b/lib/seccomp-tools/emulator.rb
@@ -46,8 +46,6 @@ module SeccompTools
     def run
       @values = { pc: 0, a: 0, x: 0 }
       loop do
-        break if @values[:ret] # break when returned
-
         yield(@values) if block_given?
         inst = @instructions[pc]
         op, *args = inst.symbolize
@@ -60,6 +58,8 @@ module SeccompTools
         when :alu then alu(args[0], args[1]) # alu
         when :misc then misc(args[0]) # misc: txa/tax
         end
+        break if @values[:ret] # break when returned
+
         set(:pc, get(:pc) + 1) if %i[ld st alu misc].include?(op)
       end
       @values
@@ -115,6 +115,9 @@ module SeccompTools
         set(:a, (2**32) - get(:a))
       else
         src = get(:x) if src == :x
+        # Classic BPF aborts the whole program on division by zero.
+        return set(:ret, Const::BPF::ACTION[:KILL_THREAD]) if op == :/ && src.zero?
+
         set(:a, get(:a).__send__(op, src))
       end
     end

--- a/spec/emulator_spec.rb
+++ b/spec/emulator_spec.rb
@@ -89,6 +89,26 @@ describe SeccompTools::Emulator do
     end
   end
 
+  context 'division by zero' do
+    def insts_of(src, arch)
+      SeccompTools::Disasm.to_bpf(SeccompTools::Asm.asm(src, arch:), arch).map(&:inst)
+    end
+
+    it 'aborts with KILL_THREAD, matching the kernel, instead of raising' do
+      # `A /= X` with X == 0: the kernel returns 0 (KILL_THREAD) from the whole program and never
+      # reaches the ALLOW, so emulation must do the same, stopping on the div instruction.
+      insts = insts_of(<<-EOS, :amd64)
+        A = 0
+        X = A
+        A /= X
+        return ALLOW
+      EOS
+      result = described_class.new(insts, arch: :amd64).run
+      expect(result[:ret]).to be 0
+      expect(result[:pc]).to be 2 # the `A /= X` line, not the unreached ALLOW
+    end
+  end
+
   context 'bdooos' do
     before do
       raw = File.binread(File.join(__dir__, 'data', 'DEF-CON-2020-bdooos.bpf'))


### PR DESCRIPTION
A filter running A /= X with X == 0 is loadable; classic BPF aborts on division by zero, returning 0 (KILL_THREAD), as verified against the kernel. The emulator now models that instead of raising ZeroDivisionError.