### PR TITLE
Add shell completion for bash, zsh and fish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `completion` command: print a shell completion script for bash, zsh or fish (e.g. `eval "$(seccomp-tools completion bash)"`).
 - `explain` command: summarize a whole filter as a per-action policy (which syscalls end in ALLOW/KILL/ERRNO, and under what argument constraints).
 - `audit` command: scan a filter for weaknesses and escape routes (missing architecture or x32 guard, permissive default, equivalent-syscall gaps, an open/read/write chain, dangerous syscalls reachable as ALLOW), with a `--format json` output.
 - RISC-V 64 (`riscv64`) architecture support across dump, disasm, asm and emu.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ $ seccomp-tools --help
 #
 # 	asm	Seccomp bpf assembler.
 # 	audit	Assess a seccomp filter for weaknesses and escape routes.
+# 	completion	Print a shell completion script.
 # 	disasm	Disassemble seccomp bpf.
 # 	dump	Automatically dump seccomp bpf from executable(s).
 # 	emu	Emulate seccomp rules.
@@ -569,6 +570,23 @@ $ seccomp-tools audit spec/data/gctf-2019-quals-caas.bpf -a amd64 -f json
 #   ]
 # }
 ```
+
+## Shell Completion
+
+`seccomp-tools completion <bash|zsh|fish>` prints a completion script for the given shell. Load it from your shell's startup file:
+
+```bash
+# bash (~/.bashrc)
+eval "$(seccomp-tools completion bash)"
+
+# zsh (~/.zshrc, after `compinit`)
+eval "$(seccomp-tools completion zsh)"
+
+# fish (~/.config/fish/config.fish)
+seccomp-tools completion fish | source
+```
+
+To avoid the startup cost of evaluating it every time, write the script to the directory your shell loads completions from instead, e.g. `seccomp-tools completion zsh > "${fpath[1]}/_seccomp-tools"`.
 
 ## Screenshots
 

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -148,6 +148,23 @@ Use `--format json` for CI or tooling:
 SHELL_OUTPUT_OF(seccomp-tools audit spec/data/gctf-2019-quals-caas.bpf -a amd64 -f json)
 ```
 
+## Shell Completion
+
+`seccomp-tools completion <bash|zsh|fish>` prints a completion script for the given shell. Load it from your shell's startup file:
+
+```bash
+# bash (~/.bashrc)
+eval "$(seccomp-tools completion bash)"
+
+# zsh (~/.zshrc, after `compinit`)
+eval "$(seccomp-tools completion zsh)"
+
+# fish (~/.config/fish/config.fish)
+seccomp-tools completion fish | source
+```
+
+To avoid the startup cost of evaluating it every time, write the script to the directory your shell loads completions from instead, e.g. `seccomp-tools completion zsh > "${fpath[1]}/_seccomp-tools"`.
+
 ## Screenshots
 
 ### Dump

--- a/completions/_seccomp-tools
+++ b/completions/_seccomp-tools
@@ -1,0 +1,83 @@
+#compdef seccomp-tools
+
+# zsh completion for seccomp-tools
+#
+# Load it with either:
+#   eval "$(seccomp-tools completion zsh)"    # in ~/.zshrc, after `compinit`
+# or drop this file (named `_seccomp-tools`) into a directory on your $fpath.
+
+_seccomp-tools() {
+  local -a arches=(aarch64 amd64 i386 riscv64 s390x)
+
+  # $words is 1-indexed; words[1]=seccomp-tools, words[2]=subcommand.
+  if (( CURRENT == 2 )); then
+    local -a commands=(
+      'asm:Seccomp bpf assembler'
+      'audit:Assess a filter for weaknesses and escape routes'
+      'completion:Print a shell completion script'
+      'disasm:Disassemble seccomp bpf'
+      'dump:Automatically dump seccomp bpf from executable(s)'
+      'emu:Emulate seccomp rules'
+      'explain:Summarize a filter as a per-action policy'
+    )
+    _describe 'command' commands
+    return
+  fi
+
+  case ${words[2]} in
+    asm)
+      _arguments \
+        '(-o --output)'{-o,--output}'[write output to FILE]:file:_files' \
+        '(-f --format)'{-f,--format}'[output format]:format:(inspect raw c_array c_source assembly)' \
+        '(-a --arch)'{-a,--arch}"[architecture]:arch:($arches)" \
+        '1:input asm file:_files'
+      ;;
+    disasm)
+      _arguments \
+        '(-o --output)'{-o,--output}'[write output to FILE]:file:_files' \
+        '(-a --arch)'{-a,--arch}"[architecture]:arch:($arches)" \
+        '--asm-able[emit output that is valid input for asm]' \
+        '(--bpf --no-bpf)--no-bpf[hide the raw BPF bytes]' \
+        '(--arg-infer --no-arg-infer)--no-arg-infer[do not infer argument names]' \
+        '1:bpf file:_files'
+      ;;
+    dump)
+      _arguments \
+        '(-c --sh-exec)'{-c,--sh-exec}'[run command via sh and dump its seccomp]:command:' \
+        '(-p --pid)'{-p,--pid}'[dump filters of a running process]:pid:' \
+        '(-l --limit)'{-l,--limit}'[dump only the first N filters]:limit:' \
+        '(-t --timeout)'{-t,--timeout}'[timeout in seconds]:seconds:' \
+        '(-f --format)'{-f,--format}'[output format]:format:(disasm raw inspect)' \
+        '(-o --output)'{-o,--output}'[write output to FILE]:file:_files' \
+        '1:executable:_files'
+      ;;
+    audit|explain)
+      _arguments \
+        '(-c --sh-exec)'{-c,--sh-exec}'[run command via sh]:command:' \
+        '(-p --pid)'{-p,--pid}'[analyze a running process]:pid:' \
+        '(-l --limit)'{-l,--limit}'[analyze only the first N filters]:limit:' \
+        '(-t --timeout)'{-t,--timeout}'[timeout in seconds]:seconds:' \
+        '(-a --arch)'{-a,--arch}"[architecture]:arch:($arches)" \
+        '(-f --format)'{-f,--format}'[output format]:format:(human json)' \
+        '1:bpf file or executable:_files'
+      ;;
+    emu)
+      _arguments \
+        '(-a --arch)'{-a,--arch}"[architecture]:arch:($arches)" \
+        '(-q --quiet)'{-q,--quiet}'[only show the emulation result]' \
+        '(-i --ip)'{-i,--ip}'[set the instruction pointer]:ip:' \
+        '1:bpf file:_files'
+      ;;
+    completion)
+      _arguments '1:shell:(bash zsh fish)'
+      ;;
+  esac
+}
+
+# When autoloaded from $fpath the completion system calls this function directly;
+# when eval'd or sourced, register it instead of running it.
+if [ "${funcstack[1]}" = "_seccomp-tools" ]; then
+  _seccomp-tools "$@"
+else
+  compdef _seccomp-tools seccomp-tools
+fi

--- a/completions/seccomp-tools.bash
+++ b/completions/seccomp-tools.bash
@@ -1,0 +1,59 @@
+# bash completion for seccomp-tools
+#
+# Load it with either:
+#   eval "$(seccomp-tools completion bash)"    # in ~/.bashrc
+# or drop this file into a bash-completion directory named `seccomp-tools`, e.g.
+#   ~/.local/share/bash-completion/completions/seccomp-tools
+
+_seccomp_tools() {
+  local cur prev cmd
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  local commands="asm audit completion disasm dump emu explain"
+  local arches="aarch64 amd64 i386 riscv64 s390x"
+
+  # Position 1: the subcommand.
+  if [[ $COMP_CWORD -eq 1 ]]; then
+    COMPREPLY=( $(compgen -W "$commands --help --version" -- "$cur") )
+    return
+  fi
+
+  cmd="${COMP_WORDS[1]}"
+
+  # The previous word expects a value: complete just that value.
+  case "$prev" in
+    -a|--arch) COMPREPLY=( $(compgen -W "$arches" -- "$cur") ); return ;;
+    -o|--output) COMPREPLY=( $(compgen -f -- "$cur") ); return ;;
+    -f|--format)
+      case "$cmd" in
+        asm)   COMPREPLY=( $(compgen -W "inspect raw c_array c_source assembly" -- "$cur") ) ;;
+        audit) COMPREPLY=( $(compgen -W "human json" -- "$cur") ) ;;
+        dump)  COMPREPLY=( $(compgen -W "disasm raw inspect" -- "$cur") ) ;;
+      esac
+      return ;;
+  esac
+
+  if [[ $cmd == completion ]]; then
+    COMPREPLY=( $(compgen -W "bash zsh fish" -- "$cur") )
+    return
+  fi
+
+  # Otherwise: this subcommand's flags (when typing a -flag) or a file.
+  local opts="-h --help"
+  case "$cmd" in
+    asm)     opts+=" -o --output -f --format -a --arch" ;;
+    disasm)  opts+=" -o --output -a --arch --bpf --no-bpf --arg-infer --no-arg-infer --asm-able" ;;
+    dump)    opts+=" -c --sh-exec -l --limit -p --pid -t --timeout -f --format -o --output" ;;
+    emu)     opts+=" -a --arch -q --no-quiet -i --ip" ;;
+    explain) opts+=" -c --sh-exec -l --limit -p --pid -t --timeout -a --arch" ;;
+    audit)   opts+=" -c --sh-exec -l --limit -p --pid -t --timeout -a --arch -f --format" ;;
+  esac
+
+  if [[ $cur == -* ]]; then
+    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+  else
+    COMPREPLY=( $(compgen -f -- "$cur") )
+  fi
+}
+complete -F _seccomp_tools seccomp-tools

--- a/completions/seccomp-tools.fish
+++ b/completions/seccomp-tools.fish
@@ -1,0 +1,52 @@
+# fish completion for seccomp-tools
+#
+# Load it with either:
+#   seccomp-tools completion fish | source    # in ~/.config/fish/config.fish
+# or drop this file into ~/.config/fish/completions/seccomp-tools.fish
+
+# Disable file completion by default; re-enabled per option/positional below.
+complete -c seccomp-tools -f
+
+# Subcommands (offered only when none has been given yet).
+complete -c seccomp-tools -n __fish_use_subcommand -a asm        -d 'Seccomp bpf assembler'
+complete -c seccomp-tools -n __fish_use_subcommand -a audit      -d 'Assess a filter for weaknesses and escape routes'
+complete -c seccomp-tools -n __fish_use_subcommand -a completion -d 'Print a shell completion script'
+complete -c seccomp-tools -n __fish_use_subcommand -a disasm     -d 'Disassemble seccomp bpf'
+complete -c seccomp-tools -n __fish_use_subcommand -a dump       -d 'Automatically dump seccomp bpf from executable(s)'
+complete -c seccomp-tools -n __fish_use_subcommand -a emu        -d 'Emulate seccomp rules'
+complete -c seccomp-tools -n __fish_use_subcommand -a explain    -d 'Summarize a filter as a per-action policy'
+complete -c seccomp-tools -n __fish_use_subcommand -l version    -d 'Show version'
+complete -c seccomp-tools -s h -l help -d 'Show help'
+
+# --arch, shared by the analysis commands.
+complete -c seccomp-tools -n '__fish_seen_subcommand_from asm disasm emu explain audit' \
+  -s a -l arch -x -a 'aarch64 amd64 i386 riscv64 s390x' -d Architecture
+
+# --format, whose valid values differ per command.
+complete -c seccomp-tools -n '__fish_seen_subcommand_from asm'   -s f -l format -x -a 'inspect raw c_array c_source assembly' -d 'Output format'
+complete -c seccomp-tools -n '__fish_seen_subcommand_from dump'  -s f -l format -x -a 'disasm raw inspect' -d 'Output format'
+complete -c seccomp-tools -n '__fish_seen_subcommand_from audit' -s f -l format -x -a 'human json' -d 'Output format'
+
+# --output takes a file.
+complete -c seccomp-tools -n '__fish_seen_subcommand_from asm disasm dump' -s o -l output -r -d 'Write output to FILE'
+
+# Options shared by the commands that read from a process.
+complete -c seccomp-tools -n '__fish_seen_subcommand_from dump explain audit' -s c -l sh-exec -x -d 'Run command via sh and analyze its seccomp'
+complete -c seccomp-tools -n '__fish_seen_subcommand_from dump explain audit' -s p -l pid     -x -d 'Analyze a running process'
+complete -c seccomp-tools -n '__fish_seen_subcommand_from dump explain audit' -s l -l limit   -x -d 'Analyze only the first N filters'
+complete -c seccomp-tools -n '__fish_seen_subcommand_from dump explain audit' -s t -l timeout -x -d 'Timeout in seconds'
+
+# disasm-only flags.
+complete -c seccomp-tools -n '__fish_seen_subcommand_from disasm' -l asm-able     -d 'Emit output that is valid input for asm'
+complete -c seccomp-tools -n '__fish_seen_subcommand_from disasm' -l no-bpf       -d 'Hide the raw BPF bytes'
+complete -c seccomp-tools -n '__fish_seen_subcommand_from disasm' -l no-arg-infer -d 'Do not infer argument names'
+
+# emu-only flags.
+complete -c seccomp-tools -n '__fish_seen_subcommand_from emu' -s i -l ip    -x -d 'Set the instruction pointer'
+complete -c seccomp-tools -n '__fish_seen_subcommand_from emu' -s q -l quiet -d 'Only show the emulation result'
+
+# completion takes a shell name.
+complete -c seccomp-tools -n '__fish_seen_subcommand_from completion' -a 'bash zsh fish' -d Shell
+
+# The commands whose positional argument is a file/executable get file completion.
+complete -c seccomp-tools -n '__fish_seen_subcommand_from asm disasm dump emu explain audit' -F

--- a/lib/seccomp-tools/cli/cli.rb
+++ b/lib/seccomp-tools/cli/cli.rb
@@ -2,6 +2,7 @@
 
 require 'seccomp-tools/cli/asm'
 require 'seccomp-tools/cli/audit'
+require 'seccomp-tools/cli/completion'
 require 'seccomp-tools/cli/disasm'
 require 'seccomp-tools/cli/dump'
 require 'seccomp-tools/cli/emu'
@@ -15,6 +16,7 @@ module SeccompTools
     COMMANDS = {
       'asm' => SeccompTools::CLI::Asm,
       'audit' => SeccompTools::CLI::Audit,
+      'completion' => SeccompTools::CLI::Completion,
       'disasm' => SeccompTools::CLI::Disasm,
       'dump' => SeccompTools::CLI::Dump,
       'emu' => SeccompTools::CLI::Emu,

--- a/lib/seccomp-tools/cli/completion.rb
+++ b/lib/seccomp-tools/cli/completion.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/cli/base'
+require 'seccomp-tools/logger'
+
+module SeccompTools
+  module CLI
+    # Handle 'completion' command.
+    class Completion < Base
+      # Summary of this command.
+      SUMMARY = 'Print a shell completion script.'
+      # Usage of this command.
+      USAGE = "completion - #{SUMMARY}\n\nUsage: seccomp-tools completion <bash|zsh|fish>".freeze
+
+      # Maps a shell name to the completion script that ships with the gem.
+      SCRIPTS = { 'bash' => 'seccomp-tools.bash', 'zsh' => '_seccomp-tools', 'fish' => 'seccomp-tools.fish' }.freeze
+
+      # Define option parser.
+      # @return [OptionParser]
+      #   The parser of this command's options.
+      def parser
+        @parser ||= OptionParser.new do |opt|
+          opt.banner = usage
+        end
+      end
+
+      # Writes the completion script for the requested shell to stdout.
+      # @return [void]
+      def handle
+        return unless super
+
+        shell = argv.shift
+        file = SCRIPTS[shell]
+        return CLI.show(parser.help) if file.nil?
+
+        output { File.read(File.join(__dir__, '..', '..', '..', 'completions', file)) }
+      end
+    end
+  end
+end

--- a/seccomp-tools.gemspec
+++ b/seccomp-tools.gemspec
@@ -18,7 +18,7 @@ Visit https://github.com/david942j/seccomp-tools for more details.
   s.email         = ['david942j@gmail.com']
   s.files         = Dir['lib/**/*.rb'] + Dir['lib/**/*.y'] +
                     Dir['lib/seccomp-tools/templates/*'] + Dir['bin/*'] + Dir['ext/**/*'] +
-                    %w(README.md CHANGELOG.md LICENSE)
+                    Dir['completions/*'] + %w(README.md CHANGELOG.md LICENSE)
   s.extensions    = %w[ext/ptrace/extconf.rb]
   s.executables   = 'seccomp-tools'
 

--- a/spec/cli/completion_spec.rb
+++ b/spec/cli/completion_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'seccomp-tools/cli/cli'
+
+describe SeccompTools::CLI::Completion do
+  def completions_dir
+    File.join(__dir__, '..', '..', 'completions')
+  end
+
+  it 'prints the bash script' do
+    expected = File.read(File.join(completions_dir, 'seccomp-tools.bash'))
+    expect { described_class.new(%w[bash]).handle }.to output(expected).to_stdout
+  end
+
+  it 'prints the zsh script' do
+    expected = File.read(File.join(completions_dir, '_seccomp-tools'))
+    expect { described_class.new(%w[zsh]).handle }.to output(expected).to_stdout
+  end
+
+  it 'prints the fish script' do
+    expected = File.read(File.join(completions_dir, 'seccomp-tools.fish'))
+    expect { described_class.new(%w[fish]).handle }.to output(expected).to_stdout
+  end
+
+  it 'shows usage when no shell is given' do
+    expect { described_class.new([]).handle }.to output(/Usage: seccomp-tools completion <bash\|zsh\|fish>/).to_stdout
+  end
+
+  it 'shows usage for an unsupported shell' do
+    expect { described_class.new(%w[powershell]).handle }
+      .to output(/Usage: seccomp-tools completion <bash\|zsh\|fish>/).to_stdout
+  end
+end

--- a/spec/cli/help_spec.rb
+++ b/spec/cli/help_spec.rb
@@ -11,6 +11,7 @@ List of commands:
 
 	asm	Seccomp bpf assembler.
 	audit	Assess a seccomp filter for weaknesses and escape routes.
+	completion	Print a shell completion script.
 	disasm	Disassemble seccomp bpf.
 	dump	Automatically dump seccomp bpf from executable(s).
 	emu	Emulate seccomp rules.


### PR DESCRIPTION
New 'completion' command prints a completion script for the given shell, e.g. eval "$(seccomp-tools completion bash)". The scripts ship in the gem under completions/ and are also usable directly on the shell's fpath.