### PR TITLE
Drop the os gem dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Dropped the `os` gem dependency; host-OS detection now uses `RbConfig`, so seccomp-tools installs with fewer dependencies.
+
 ## [1.7.0] - 2026-08-01
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     seccomp-tools (1.7.0)
       logger
-      os (~> 1.1, >= 1.1.1)
       racc (~> 1.8)
 
 GEM
@@ -15,7 +14,6 @@ GEM
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
-    os (1.1.4)
     ostruct (0.6.3)
     parallel (1.28.0)
     parser (3.3.12.0)

--- a/lib/seccomp-tools/dumper.rb
+++ b/lib/seccomp-tools/dumper.rb
@@ -1,19 +1,18 @@
 # frozen_string_literal: true
 
-require 'os'
 require 'timeout'
 
 require 'seccomp-tools/logger'
-require 'seccomp-tools/ptrace' if OS.linux?
-require 'seccomp-tools/syscall'
 require 'seccomp-tools/util'
+require 'seccomp-tools/ptrace' if SeccompTools::Util.linux?
+require 'seccomp-tools/syscall'
 
 module SeccompTools
   # Dump seccomp-bpf using ptrace of binary.
   module Dumper
     # Whether the dumper is supported.
     # Dumper works based on ptrace, so we need the platform to be Linux.
-    SUPPORTED = OS.linux?
+    SUPPORTED = Util.linux?
 
     module_function
 

--- a/lib/seccomp-tools/syscall.rb
+++ b/lib/seccomp-tools/syscall.rb
@@ -1,11 +1,9 @@
 # encoding: ascii-8bit
 # frozen_string_literal: true
 
-require 'os'
-
 require 'seccomp-tools/const'
 require 'seccomp-tools/util'
-require 'seccomp-tools/ptrace' if OS.linux?
+require 'seccomp-tools/ptrace' if SeccompTools::Util.linux?
 
 module SeccompTools
   # Record syscall number, arguments, return value.

--- a/lib/seccomp-tools/util.rb
+++ b/lib/seccomp-tools/util.rb
@@ -16,6 +16,12 @@ module SeccompTools
                               .sort
     end
 
+    # Whether the host operating system is Linux, where the +ptrace+-based dumping works.
+    # @return [Boolean]
+    def linux?
+      RbConfig::CONFIG['host_os'].include?('linux')
+    end
+
     # Detect system architecture.
     # @return [Symbol]
     #   One of {supported_archs}, or +:unknown+ if the host CPU is not supported.

--- a/seccomp-tools.gemspec
+++ b/seccomp-tools.gemspec
@@ -41,6 +41,5 @@ Visit https://github.com/david942j/seccomp-tools for more details.
   s.add_development_dependency 'yard', '~> 0.9'
 
   s.add_dependency 'logger'
-  s.add_dependency 'os', '~> 1.1', '>= 1.1.1'
   s.add_dependency 'racc', '~> 1.8'
 end

--- a/spec/util_spec.rb
+++ b/spec/util_spec.rb
@@ -27,6 +27,15 @@ describe SeccompTools::Util do
     RbConfig::CONFIG['host_cpu'] = org
   end
 
+  it 'linux?' do
+    org = RbConfig::CONFIG['host_os']
+    RbConfig::CONFIG['host_os'] = 'linux-gnu'
+    expect(described_class.linux?).to be true
+    RbConfig::CONFIG['host_os'] = 'darwin23'
+    expect(described_class.linux?).to be false
+    RbConfig::CONFIG['host_os'] = org
+  end
+
   it 'elf?' do
     Tempfile.create(['seccomp-tools-', '']) do |f|
       f.write("\x7fELF#{"\x00" * 12}")


### PR DESCRIPTION
Host-OS detection only needs 'is this Linux', so replace OS.linux? with a RbConfig check in Util.linux?. Removes a runtime dependency, which also eases distro packaging.