### PR TITLE
Fix i386 syscall 283 name: sys_kexec_load -> kexec_load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refreshed syscall argument names to Linux 7.1, so disasm labels the arguments of the modern syscalls (e.g. `openat2(dfd, filename, how, size)`) instead of showing bare `args[n]`.
 - Dropped the `os` gem dependency; host-OS detection now uses `RbConfig`, so seccomp-tools installs with fewer dependencies.
 
+### Fixed
+- i386 syscall 283 is now named `kexec_load`, matching every other architecture; it was mistakenly `sys_kexec_load`, so `kexec_load` did not resolve in asm/disasm on i386.
+
 ## [1.7.0] - 2026-08-01
 
 ### Added

--- a/lib/seccomp-tools/consts/sys_nr/i386.rb
+++ b/lib/seccomp-tools/consts/sys_nr/i386.rb
@@ -282,7 +282,7 @@
   mq_timedreceive: 280,
   mq_notify: 281,
   mq_getsetattr: 282,
-  sys_kexec_load: 283,
+  kexec_load: 283,
   waitid: 284,
   add_key: 286,
   request_key: 287,


### PR DESCRIPTION
The stray sys_ prefix (the kernel C entry-point name) leaked into the i386 table, so kexec_load did not resolve on i386 while it did on every other arch.